### PR TITLE
Curtis travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ install:
   - docker build -t spades:3.13.0 spades/3.13.0
   - docker build -t quast:5.0.2 quast/5.0.2
   - docker build -t shovill:1.0.4 shovill/1.0.4
+  - docker build -t samtools:1.9 samtools/1.9
 script:
   - bash tests/mash-test.sh
   - bash tests/mashtree-test.sh
   - bash tests/spades.sh
   - bash tests/quast.sh
   - bash tests/shovill.sh
+  - bash tests/samtools.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
 install:
   - docker build -t mash:2.1 mash/2.1
   - docker build -t mashtree:0.52 mashtree/0.52.0
+  - docker build -t spades:3.13.0 spades/3.13.0
 script:
   - bash tests/mash-test.sh
   - bash tests/mashtree-test.sh
+  - bash tests/spades.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ install:
   - docker build -t mashtree:0.52 mashtree/0.52.0
   - docker build -t spades:3.13.0 spades/3.13.0
   - docker build -t quast:5.0.2 quast/5.0.2
+  - docker build -t shovill:1.0.4 shovill/1.0.4
 script:
   - bash tests/mash-test.sh
   - bash tests/mashtree-test.sh
   - bash tests/spades.sh
   - bash tests/quast.sh
+  - bash tests/shovill.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ install:
   - docker build -t mash:2.1 mash/2.1
   - docker build -t mashtree:0.52 mashtree/0.52.0
   - docker build -t spades:3.13.0 spades/3.13.0
+  - docker build -t quast:5.0.2 quast/5.0.2
 script:
   - bash tests/mash-test.sh
   - bash tests/mashtree-test.sh
   - bash tests/spades.sh
+  - bash tests/quast.sh

--- a/quast/5.0.2/Dockerfile
+++ b/quast/5.0.2/Dockerfile
@@ -38,9 +38,7 @@ RUN wget https://github.com/ablab/quast/releases/download/quast_5.0.2/quast-5.0.
     tar -xzf quast-5.0.2.tar.gz && \
     rm -r quast-5.0.2.tar.gz
 RUN cd /quast-5.0.2 && \
-    /quast-5.0.2/setup.py install
-RUN cd /quast-5.0.2 && \
-    /quast-5.0.2/setup.py test && \
+    /quast-5.0.2/setup.py install && \
     mkdir /data
 
 WORKDIR /data

--- a/tests/quast.sh
+++ b/tests/quast.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# test for quast 5.0.2
+
+docker run quast:5.0.2 quast.py --help
+
+# this command runs the test since 'quast.py --test' alone doesn't work
+docker run quast:5.0.2 /bin/bash -c 'cd /quast-5.0.2/; /quast-5.0.2/setup.py test'

--- a/tests/samtools.sh
+++ b/tests/samtools.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# test for samtools 1.9
+set -e
+
+docker run samtools:1.9 /bin/bash -c 'cd /samtools/samtools-1.9; make test'

--- a/tests/shovill.sh
+++ b/tests/shovill.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# test for Shovill 1.0.4
+set -e
+
+docker run shovill:1.0.4 /shovill/shovill-1.0.4/test/test.sh

--- a/tests/spades.sh
+++ b/tests/spades.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# test for spades container
+set -e
+
+docker run spades:3.13.0 spades.py
+docker run spades:3.13.0 spades.py --test 


### PR DESCRIPTION
This PR adds:

- travisCI tests for shovill, spades, quast, and samtools

This PR changes:

- quast 5.0.2 dockerfile to no longer carry out `setup.py test`. Now performed by travisCI test.

Will rebuild quast5.0.2 docker image on dockerhub shortly