### PR TITLE
format appropriate bed file

### DIFF
--- a/ivar/1.1-SC2/Dockerfile
+++ b/ivar/1.1-SC2/Dockerfile
@@ -20,8 +20,8 @@ RUN git clone -n https://github.com/artic-network/artic-ncov2019.git &&\
     git checkout d50a5f6a3265fb45a5d0c8949dfd037fd869f8f9 
 # Reformat Artic BED files for use in iVar
 RUN mkdir reference &&\
-    perl -ne 'my @x=split m/\t/; print join("\t",@x[0..3], 60, $x[3]=~m/LEFT/?"+":"-"),"\n";' < artic-ncov2019/primer_schemes/nCoV-2019/V1/nCoV-2019.scheme.bed  > /reference/ARTIC-V1.bed &&\
-    perl -ne 'my @x=split m/\t/; print join("\t",@x[0..3], 60, $x[3]=~m/LEFT/?"+":"-"),"\n";' < artic-ncov2019/primer_schemes/nCoV-2019/V2/nCoV-2019.scheme.bed  > /reference/ARTIC-V2.bed &&\
+    perl -ne 'my @x=split m/\t/; print join("\t",@x[0..3], 60, $x[3]=~m/LEFT/?"+":"-"),"\n";' < artic-ncov2019/primer_schemes/nCoV-2019/V1/nCoV-2019.bed  > /reference/ARTIC-V1.bed &&\
+    perl -ne 'my @x=split m/\t/; print join("\t",@x[0..3], 60, $x[3]=~m/LEFT/?"+":"-"),"\n";' < artic-ncov2019/primer_schemes/nCoV-2019/V2/nCoV-2019.bed  > /reference/ARTIC-V2.bed &&\
     mv artic-ncov2019/primer_schemes/nCoV-2019/V1/nCoV-2019.reference.fasta /reference 
 # Seqtk
 RUN mkdir seqtk &&\

--- a/ivar/1.2.1-SC2/Dockerfile
+++ b/ivar/1.2.1-SC2/Dockerfile
@@ -23,8 +23,8 @@ RUN git clone -n https://github.com/artic-network/artic-ncov2019.git &&\
     git checkout d50a5f6a3265fb45a5d0c8949dfd037fd869f8f9
 # Reformat Artic BED files for use in iVar
 RUN mkdir reference &&\
-    mv artic-ncov2019/primer_schemes/nCoV-2019/V1/nCoV-2019.scheme.bed  /reference/ARTIC-V1.bed &&\
-    mv artic-ncov2019/primer_schemes/nCoV-2019/V2/nCoV-2019.scheme.bed  /reference/ARTIC-V2.bed &&\
+    mv artic-ncov2019/primer_schemes/nCoV-2019/V1/nCoV-2019.bed  /reference/ARTIC-V1.bed &&\
+    mv artic-ncov2019/primer_schemes/nCoV-2019/V2/nCoV-2019.bed  /reference/ARTIC-V2.bed &&\
     awk -F $'\t' 'BEGIN{OFS=FS;}{$5=60;print}' artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.bed  > /reference/ARTIC-V3.bed &&\
     mv artic-ncov2019/primer_schemes/nCoV-2019/V1/nCoV-2019.reference.fasta /reference
 # Seqtk


### PR DESCRIPTION
Ensuring that the reference bed files all come from the .bed files rather than the .scheme.bed