### PR TITLE
Update Pangolin recipe to version 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For many people Docker is not an option, but Singularity is. Most Docker contain
 | [NanoPlot](https://hub.docker.com/r/staphb/nanoplot) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/nanoplot.svg?style=popout)](https://hub.docker.com/r/staphb/nanoplot) | 1.27.0, 1.29.0, 1.30.1 | https://github.com/wdecoster/NanoPlot |
 | [NCBI AMRFinderPlus](https://hub.docker.com/r/staphb/ncbi-amrfinderplus) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/ncbi-amrfinderplus.svg?style=popout)](https://hub.docker.com/r/staphb/ncbi-amrfinderplus) | 3.1.1b, 3.8.4 | [https://github.com/ncbi/amr](https://github.com/ncbi/amr) |
 | [OrthoFinder](https://hub.docker.com/r/staphb/OrthoFinder) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/orthofinder.svg?style=popout)](https://hub.docker.com/r/staphb/orthofinder) | 2.17 | https://github.com/davidemms/OrthoFinder |
-| [Pangolin](https://hub.docker.com/r/staphb/pangolin) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/pangolin.svg?style=popout)](https://hub.docker.com/r/staphb/pangolin) | 1.1.14 | https://github.com/hCoV-2019/pangolin |
+| [Pangolin](https://hub.docker.com/r/staphb/pangolin) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/pangolin.svg?style=popout)](https://hub.docker.com/r/staphb/pangolin) | 1.1.14, 2.0.4 | https://github.com/hCoV-2019/pangolin |
 | [Pilon](https://hub.docker.com/r/staphb/pilon) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/pilon.svg?style=popout)](https://hub.docker.com/r/staphb/pilon) | 1.23.0 | https://github.com/broadinstitute/pilon |
 | [PlasmidSeeker](https://hub.docker.com/r/staphb/plasmidseeker) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/plasmidseeker.svg?style=popout)](https://hub.docker.com/r/staphb/plasmidseeker) | 1.0 | https://github.com/bioinfo-ut/PlasmidSeeker |
 | [Prokka](https://hub.docker.com/r/staphb/prokka/) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/prokka.svg?style=popout)](https://hub.docker.com/r/staphb/prokka) | 1.13.4, 1.14.0, 1.14.5 | https://github.com/tseemann/prokka |
@@ -103,3 +103,4 @@ Each Dockerfile lists the author(s)/maintainer(s) as a metadata `LABEL`, but the
   * [@lskatz](https://github.com/lskatz)
   * [@stjacqrm](https://github.com/stjacqrm)
   * [@AbigailShockey](https://github.com/AbigailShockey)
+  * [@andersgs](https://github.com/andersgs)

--- a/pangolin/2.0.4/Dockerfile
+++ b/pangolin/2.0.4/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:xenial
+
+ENV PANGOLIN_VERSION="2.0.4"\ 
+  PANGOLIN_LEARN_VERSION="2020-07-20"\
+  PANGOLIN_LINEAGES_COMMIT_HASH="549d108a55cad80b35255f4ecda24e351eeadadb"
+
+LABEL base.image="ubuntu:xenial"
+LABEL dockerfile.version="1"
+LABEL software="pangolin"
+LABEL software.version=${PANGOLIN_VERSION}
+LABEL description="Conda environment for Pangolin. Pangolin: Software package for assigning SARS-CoV-2 genome sequences to global lineages."
+LABEL website="https://github.com/cov-lineages/pangolin"
+LABEL license="GNU General Public License v3.0"
+LABEL license.url="https://github.com/cov-lineages/pangolin/blob/master/LICENSE.txt"
+LABEL maintainer="Erin Young"
+LABEL maintainer.email="eriny@utah.gov"
+LABEL maintainer2="Anders Goncalves da Silva"
+LABEL maintainer2.email="andersgs@gmail.com"
+
+# install needed software for conda install
+RUN apt-get update && apt-get install -y \
+  wget \
+  git \
+  build-essential
+
+# get miniconda and the pangolin repo
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+ bash ./Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b  && \
+  rm Miniconda3-latest-Linux-x86_64.sh && \
+  wget "https://github.com/cov-lineages/pangolin/archive/v${PANGOLIN_VERSION}.tar.gz" && \
+  tar -xf v${PANGOLIN_VERSION}.tar.gz && \
+  mv pangolin-${PANGOLIN_VERSION} pangolin
+
+# set the environment
+ENV PATH="/miniconda/bin:$PATH" \
+ LC_ALL=C
+
+# create the conda environment and set as default
+RUN conda env create -f /pangolin/environment.yml
+RUN echo "source activate pangolin" > /etc/bash.bashrc
+ENV PATH /miniconda/envs/pangolin/bin:$PATH
+RUN cd pangolin && \
+ python setup.py install && \
+ mkdir /data
+
+# install and update pangolin learn
+# do it here to allow for caching of the previous layers
+
+RUN /bin/bash -c 'cd .. && \
+ source activate pangolin && \
+ wget https://github.com/cov-lineages/pangoLEARN/archive/${PANGOLIN_LEARN_VERSION}.tar.gz && \
+ tar -xf ${PANGOLIN_LEARN_VERSION}.tar.gz && \
+ cd pangoLEARN-${PANGOLIN_LEARN_VERSION} && \
+ pip install .'
+
+# install the latest lineages release
+# looks like it will be deprecated
+# because no more tagged releases are planned,
+# I am working off commit hashes to aid in 
+# reproduciability
+
+RUN /bin/bash -c 'cd .. && \
+ source activate pangolin && \
+ git clone https://github.com/cov-lineages/lineages.git && \
+ cd lineages && \
+ git checkout ${PANGOLIN_LINEAGES_COMMIT_HASH} && \
+ pip install .'
+
+WORKDIR /data
+
+RUN pangolin -v && pangolin -lv && pangolin -pv


### PR DESCRIPTION
This update Includes installation of PangoLEARN, and pulling out version information to an ENV statement so it is easy to generate updates.

I also use the version numbers to specify the download of specific tagged releases in GitHub to aid in the reproducibility of the build.