### PR TITLE
Samtools update to 1.12

### DIFF
--- a/bcftools/1.12/Dockerfile
+++ b/bcftools/1.12/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:xenial
+
+# for easy upgrade later. ARG variables only persist during build time
+ARG bcftoolsVer="1.12"
+
+LABEL base.image="ubuntu:xenial"
+LABEL dockerfile.version="1"
+LABEL software="bcftools"
+LABEL software.version="1.12"
+LABEL description="Variant calling and manipulating files in the Variant Call Format (VCF) and its binary counterpart BCF"
+LABEL website="https://github.com/samtools/bcftools"
+LABEL license="https://github.com/samtools/bcftools/blob/develop/LICENSE"
+LABEL maintainer="Erin Young"
+LABEL maintainer.email="eriny@utah.gov"
+
+# install dependencies, cleanup apt garbage
+RUN apt-get update && apt-get install --no-install-recommends -y \
+ wget \
+ ca-certificates \
+ perl \
+ bzip2 \
+ autoconf \
+ automake \
+ make \
+ gcc \
+ zlib1g-dev \
+ libbz2-dev \
+ liblzma-dev \
+ libcurl4-gnutls-dev \
+ libssl-dev \
+ libperl-dev \
+ libgsl0-dev && \
+ rm -rf /var/lib/apt/lists/* && apt-get autoclean
+
+# get bcftools and make /data
+RUN wget https://github.com/samtools/bcftools/releases/download/${bcftoolsVer}/bcftools-${bcftoolsVer}.tar.bz2 && \
+ tar -vxjf bcftools-${bcftoolsVer}.tar.bz2 && \
+ rm bcftools-${bcftoolsVer}.tar.bz2 && \
+ cd bcftools-${bcftoolsVer} && \
+ make && \
+ make install && \
+ mkdir /data
+
+# set $PATH (honestly unnecessary here, lol) and locale settings for singularity compatibility
+ENV PATH="$PATH" \
+ LC_ALL=C
+
+# set working directory
+WORKDIR /data

--- a/bcftools/1.12/Readme.md
+++ b/bcftools/1.12/Readme.md
@@ -1,0 +1,12 @@
+# bcftools container
+
+Main tool : [bcftools](https://www.htslib.org/)
+
+
+# Example Usage
+
+```
+bcftools mpileup -A -d 200 -B -Q 0 -f {reference_genome} {bam} | bcftools call -mv -Ov -o bcftools_variants/{sample}.vcf
+```
+
+Better documentation can be found at [https://www.htslib.org/doc/bcftools.html](https://www.htslib.org/doc/bcftools.html)

--- a/ivar/1.3.1/Dockerfile
+++ b/ivar/1.3.1/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:18.04
 
 # for easy upgrade later. ARG variables only persist during image build
-ARG SAMTOOLSVER=1.11
-ARG HTSLIBVER=1.11
+ARG SAMTOOLSVER=1.12
+ARG HTSLIBVER=1.12
 ARG IVARVER=1.3.1
 
 LABEL base.image="ubuntu:18.04"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="iVar"
 LABEL software.version="1.3.1"
 LABEL description="Computational package that contains functions broadly useful for viral amplicon-based sequencing."
-LABEL comments="Contains iVar 1.3.1 as well as htslib/samtools 1.11"
+LABEL comments="Contains iVar 1.3.1 as well as htslib/samtools 1.12"
 LABEL website="https://github.com/andersen-lab/ivar"
 LABEL license="https://github.com/andersen-lab/ivar/blob/master/LICENSE"
 LABEL maintainer1="Erin Young"

--- a/samtools/1.12/Dockerfile
+++ b/samtools/1.12/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:xenial
+
+# for easy upgrade later. ARG variables only persist during image build
+ARG SAMTOOLSVER=1.12
+
+LABEL base.image="ubuntu:xenial"
+LABEL dockerfile.version="1"
+LABEL software="Samtools"
+LABEL software.version="1.12"
+LABEL description="Tools (written in C using htslib) for manipulating next-generation sequencing data"
+LABEL website="https://github.com/samtools/samtools"
+LABEL license="https://github.com/samtools/samtools/blob/develop/LICENSE"
+LABEL maintainer="Erin Young"
+LABEL maintainer.email="eriny@utah.gov"
+
+# install dependencies and clean up apt garbage
+RUN apt-get update && apt-get install --no-install-recommends -y \
+ libncurses5-dev \
+ libbz2-dev \
+ liblzma-dev \
+ libcurl4-gnutls-dev \
+ zlib1g-dev \
+ libssl-dev \
+ gcc \
+ wget \
+ make \
+ perl \
+ bzip2 \
+ ca-certificates && \
+ apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# install samtools, make /data
+RUN wget https://github.com/samtools/samtools/releases/download/${SAMTOOLSVER}/samtools-${SAMTOOLSVER}.tar.bz2 && \
+ tar -xjf samtools-${SAMTOOLSVER}.tar.bz2 && \
+ rm samtools-${SAMTOOLSVER}.tar.bz2 && \
+ cd samtools-${SAMTOOLSVER} && \
+ ./configure && \
+ make && \
+ make install && \
+ mkdir /data
+
+# set perl locale settings
+ENV LC_ALL=C
+
+WORKDIR /data

--- a/samtools/1.12/Readme.md
+++ b/samtools/1.12/Readme.md
@@ -1,0 +1,15 @@
+# samtools container
+
+Main tool : [samtools](https://www.htslib.org/)
+
+
+# Example Usage
+
+```
+samtools ampliconclip -b bed.file input.bam
+```
+```
+samtools sort -T /tmp/aln.sorted -o aln.sorted.bam aln.bam
+```
+
+Better documentation can be found at [https://www.htslib.org/doc/samtools.html](https://www.htslib.org/doc/samtools.html)


### PR DESCRIPTION
htslib has updated to 1.12

I've created new files for the new samtools and bcftools docker images ( plus accompanying readmes )

I've also updated iVar 1.3.1 to the new version of samtools

More information can be found at https://www.htslib.org/download/