### PR TITLE
Vadr 1.2.1 dev

### DIFF
--- a/vadr/1.2.1/Dockerfile
+++ b/vadr/1.2.1/Dockerfile
@@ -1,12 +1,14 @@
 # base image
 FROM ubuntu:xenial
 
+# for easy upgrade later. LC_ALL set for singularity compatibility
 ENV VADR_VERSION="1.2" \
   VADR_SARSCOV2_MODELS_VERSION="1.2-2" \
   LC_ALL=C \
   VADRINSTALLDIR=/opt/vadr
 
 ENV VADRSCRIPTSDIR=$VADRINSTALLDIR/vadr \
+ VADRMINISCRIPTSDIR=$VADRINSTALLDIR/vadr/miniscripts \
  VADRMODELDIR=$VADRINSTALLDIR/vadr-models \
  VADRINFERNALDIR=$VADRINSTALLDIR/infernal/binaries \
  VADREASELDIR=$VADRINSTALLDIR/infernal/binaries \
@@ -17,11 +19,11 @@ ENV VADRSCRIPTSDIR=$VADRINSTALLDIR/vadr \
  VADRFASTADIR=$VADRINSTALLDIR/fasta/bin
 
 ENV PERL5LIB=$VADRSCRIPTSDIR:$VADRSEQUIPDIR:$VADRBIOEASELDIR/blib/lib:$VADRBIOEASELDIR/blib/arch:$PERL5LIB \
- PATH=$VADRSCRIPTSDIR:$PATH
+ PATH=$VADRSCRIPTSDIR:$VADRMINISCRIPTSDIR:$PATH
 
 # metadata - optional, but highly recommended
 LABEL base.image="ubuntu:xenial"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="VADR"
 LABEL software.version=${VADR_VERSION}
 LABEL description="This software does viral annotations"
@@ -43,15 +45,30 @@ RUN apt-get update && apt-get install -y \
  apt-get install -y libinline-c-perl liblwp-protocol-https-perl && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
+### OLD ###
 # install and/or setup more things. Make /data for use as a working dir
+#RUN mkdir -p ${VADRINSTALLDIR} && \
+ # cd ${VADRINSTALLDIR} && \
+ # wget https://raw.githubusercontent.com/ncbi/vadr/release-${VADR_VERSION}/vadr-install.sh && \
+ # bash vadr-install.sh linux && \
+ # mkdir /data
+
+# install VADR
+# download entire VADR source code from GitHub release
+# use vadr-install.sh script to install VADR into $VADRINSTALLDIR (set to /opt/vadr)
+# this script grabs files from tagged release and sets things up in /opt/vadr/vadr
+# last step is to delete the original source code that is a duplicate (/opt/vadr/vadr-$VADR_VERSION)
 RUN mkdir -p ${VADRINSTALLDIR} && \
- cd ${VADRINSTALLDIR} && \
- wget https://raw.githubusercontent.com/ncbi/vadr/release-${VADR_VERSION}/vadr-install.sh && \
- bash vadr-install.sh linux && \
+ cd ${VADRINSTALLDIR} && \ 
+ wget https://github.com/ncbi/vadr/archive/refs/tags/vadr-${VADR_VERSION}.tar.gz && \
+ mkdir vadr-${VADR_VERSION} && tar -xzf vadr-${VADR_VERSION}.tar.gz -C vadr-${VADR_VERSION} --strip-components 1 && \
+ rm vadr-${VADR_VERSION}.tar.gz && \
+ bash vadr-${VADR_VERSION}/vadr-install.sh linux && \
+ rm -rf vadr-${VADR_VERSION}/ && \
  mkdir /data
 
 # install the latest sarscov2 models 
-# copy calici models into VADRMODELDIR to allow tests to pass completely
+# copy calici models into VADRMODELDIR to allow VADR tests to pass completely
 # cleanup duplicate copies of model files
 RUN wget -O vadr-models-sarscov2.tar.gz https://ftp.ncbi.nlm.nih.gov/pub/nawrocki/vadr-models/sarscov2/${VADR_SARSCOV2_MODELS_VERSION}/vadr-models-sarscov2-${VADR_SARSCOV2_MODELS_VERSION}.tar.gz && \
  tar -xf vadr-models-sarscov2.tar.gz && \

--- a/vadr/1.2.1/Dockerfile
+++ b/vadr/1.2.1/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:xenial
 
 # for easy upgrade later. LC_ALL set for singularity compatibility
-ENV VADR_VERSION="1.2" \
+ENV VADR_VERSION="1.2.1" \
   VADR_SARSCOV2_MODELS_VERSION="1.2-2" \
   LC_ALL=C \
   VADRINSTALLDIR=/opt/vadr
@@ -23,7 +23,7 @@ ENV PERL5LIB=$VADRSCRIPTSDIR:$VADRSEQUIPDIR:$VADRBIOEASELDIR/blib/lib:$VADRBIOEA
 
 # metadata - optional, but highly recommended
 LABEL base.image="ubuntu:xenial"
-LABEL dockerfile.version="2"
+LABEL dockerfile.version="1"
 LABEL software="VADR"
 LABEL software.version=${VADR_VERSION}
 LABEL description="This software does viral annotations"
@@ -44,14 +44,6 @@ RUN apt-get update && apt-get install -y \
  autoconf && \
  apt-get install -y libinline-c-perl liblwp-protocol-https-perl && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
-
-### OLD ###
-# install and/or setup more things. Make /data for use as a working dir
-#RUN mkdir -p ${VADRINSTALLDIR} && \
- # cd ${VADRINSTALLDIR} && \
- # wget https://raw.githubusercontent.com/ncbi/vadr/release-${VADR_VERSION}/vadr-install.sh && \
- # bash vadr-install.sh linux && \
- # mkdir /data
 
 # install VADR
 # download entire VADR source code from GitHub release


### PR DESCRIPTION
Adds new Dockerfile for VADR 1.2.1.

Builds successfully and test-scripts pass
```
$ /opt/vadr/vadr/testfiles/do-install-tests-local.sh

...

# Elapsed time:  00:01:01.81
#                hh:mm:ss
#
[ok]
Success: all tests passed [do-install-tests-local.sh]
```
and
```
$ /opt/vadr/vadr/testfiles/do-all-tests.sh

...

# Elapsed time:  00:00:07.75
#                hh:mm:ss
#
[ok]
Success: all tests passed [do-issue-tests.sh]
Success: all tests passed [do-all-tests.sh]
```
ran successfully on the B.1.1.7 genome Erin kindly provided
```
I have no name!@a8cc10be0767:/data$ v-annotate.pl -f --noseqnamemax --split --cpu 2 --glsearch -s -r --nomisc --mkey sarscov2 --lowsim5term 2 --lowsim3term 2 --alt_fail lowscore,fstukcnf,insertnn,deletinn testdata/SRR13957123.B.1.1.7.consensus.VADR-trimmed.fasta outputs/2021-06-17-vadr-1.2.1-test/v-annotate-test-on-B117-trimmed
# v-annotate.pl :: classify and annotate sequences using a CM library
# VADR 1.2.1 (June 2021)
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# date:              Thu Jun 17 19:10:21 2021
# $VADRBIOEASELDIR:  /opt/vadr/Bio-Easel
# $VADRBLASTDIR:     /opt/vadr/ncbi-blast/bin
# $VADREASELDIR:     /opt/vadr/infernal/binaries
# $VADRFASTADIR:     /opt/vadr/fasta/bin
# $VADRINFERNALDIR:  /opt/vadr/infernal/binaries
# $VADRMODELDIR:     /opt/vadr/vadr-models
# $VADRSCRIPTSDIR:   /opt/vadr/vadr
#
# sequence file:                                                                  testdata/SRR13957123.B.1.1.7.consensus.VADR-trimmed.fasta
# output directory:                                                               outputs/2021-06-17-vadr-1.2.1-test/v-annotate-test-on-B117-trimmed
# force directory overwrite:                                                      yes [-f]
# specify that alert codes in <s> cause FAILure:                                  lowscore,fstukcnf,insertnn,deletinn [--alt_fail]
# .cm, .minfo, blastn .fa files in $VADRMODELDIR start with key <s>, not 'vadr':  sarscov2 [--mkey]
# in feature table for failed seqs, never change feature type to misc_feature:    yes [--nomisc]
# lowsim5{s,f}/LOW_{FEATURE_}SIMILARITY_START minimum length is <n>:              2 [--lowsim5term]
# lowsim3{s,f}/LOW_{FEATURE_}SIMILARITY_END minimum length is <n>:                2 [--lowsim3term]
# align with glsearch from the FASTA package, not to a cm with cmalign:           yes [--glsearch]
# use max length ungapped region from blastn to seed the alignment:               yes [-s]
# replace stretches of Ns with expected nts, where possible:                      yes [-r]
# split input file into chunks, run each chunk separately:                        yes [--split]
# parallelize across <n> CPU workers (requires --split or --glsearch):            2 [--cpu]
# do not enforce a maximum length of 50 for sequence names (GenBank max):         yes [--noseqnamemax]
# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
# Validating input                                                                        ... done. [    0.1 seconds]
# Splitting sequence file into chunks to run independently in parallel on 2 processors    ... done. [    0.0 seconds]
# Executing 1 script to process 1 partition(s) of all 1 sequence(s)                       ... done. [    2.5 seconds]
# Merging and finalizing output                                                           ... done. [    0.1 seconds]
#
# Summary of classified sequences:
#
#                                                    num   num   num
#idx  model               group         subgroup    seqs  pass  fail
#---  ------------------  ------------  ----------  ----  ----  ----
1     NC_045512-MW422255  Sarbecovirus  SARS-CoV-2     1     1     0
#---  ------------------  ------------  ----------  ----  ----  ----
-     *all*               -             -              1     1     0
-     *none*              -             -              0     0     0
#---  ------------------  ------------  ----------  ----  ----  ----
#
# Zero alerts were reported.
#
# Output printed to screen saved in:                              v-annotate-test-on-B117-trimmed.vadr.log
# List of executed commands saved in:                             v-annotate-test-on-B117-trimmed.vadr.cmd
# List and description of all output files saved in:              v-annotate-test-on-B117-trimmed.vadr.filelist
# esl-seqstat -a output for input fasta file saved in:            v-annotate-test-on-B117-trimmed.vadr.seqstat
# 5 column feature table output for passing sequences saved in:   v-annotate-test-on-B117-trimmed.vadr.pass.tbl
# 5 column feature table output for failing sequences saved in:   v-annotate-test-on-B117-trimmed.vadr.fail.tbl
# list of passing sequences saved in:                             v-annotate-test-on-B117-trimmed.vadr.pass.list
# list of failing sequences saved in:                             v-annotate-test-on-B117-trimmed.vadr.fail.list
# list of alerts in the feature tables saved in:                  v-annotate-test-on-B117-trimmed.vadr.alt.list
# fasta file with passing sequences saved in:                     v-annotate-test-on-B117-trimmed.vadr.pass.fa
# fasta file with failing sequences saved in:                     v-annotate-test-on-B117-trimmed.vadr.fail.fa
# per-sequence tabular annotation summary file saved in:          v-annotate-test-on-B117-trimmed.vadr.sqa
# per-sequence tabular classification summary file saved in:      v-annotate-test-on-B117-trimmed.vadr.sqc
# per-feature tabular summary file saved in:                      v-annotate-test-on-B117-trimmed.vadr.ftr
# per-model-segment tabular summary file saved in:                v-annotate-test-on-B117-trimmed.vadr.sgm
# per-model tabular summary file saved in:                        v-annotate-test-on-B117-trimmed.vadr.mdl
# per-alert tabular summary file saved in:                        v-annotate-test-on-B117-trimmed.vadr.alt
# alert count tabular summary file saved in:                      v-annotate-test-on-B117-trimmed.vadr.alc
# alignment doctoring tabular summary file saved in:              v-annotate-test-on-B117-trimmed.vadr.dcr
# ungapped seed alignment summary file (-s) saved in:             v-annotate-test-on-B117-trimmed.vadr.sda
# replaced stretches of Ns summary file (-r) saved in:            v-annotate-test-on-B117-trimmed.vadr.rpn
#
# All output files created in directory ./outputs/2021-06-17-vadr-1.2.1-test/v-annotate-test-on-B117-trimmed/
#
# Elapsed time:  00:00:02.68
#                hh:mm:ss
#
[ok]
I have no name!@a8cc10be0767:/data$ ls ./outputs/2021-06-17-vadr-1.2.1-test/v-annotate-test-on-B117-trimmed/
v-annotate-test-on-B117-trimmed.vadr.alc        v-annotate-test-on-B117-trimmed.vadr.mdl
v-annotate-test-on-B117-trimmed.vadr.alt        v-annotate-test-on-B117-trimmed.vadr.pass.fa
v-annotate-test-on-B117-trimmed.vadr.alt.list   v-annotate-test-on-B117-trimmed.vadr.pass.list
v-annotate-test-on-B117-trimmed.vadr.cmd        v-annotate-test-on-B117-trimmed.vadr.pass.tbl
v-annotate-test-on-B117-trimmed.vadr.dcr        v-annotate-test-on-B117-trimmed.vadr.rpn
v-annotate-test-on-B117-trimmed.vadr.fail.fa    v-annotate-test-on-B117-trimmed.vadr.sda
v-annotate-test-on-B117-trimmed.vadr.fail.list  v-annotate-test-on-B117-trimmed.vadr.seqstat
v-annotate-test-on-B117-trimmed.vadr.fail.tbl   v-annotate-test-on-B117-trimmed.vadr.sgm
v-annotate-test-on-B117-trimmed.vadr.filelist   v-annotate-test-on-B117-trimmed.vadr.sqa
v-annotate-test-on-B117-trimmed.vadr.ftr        v-annotate-test-on-B117-trimmed.vadr.sqc
v-annotate-test-on-B117-trimmed.vadr.log
```
