### PR TITLE
add TSV to VCF script to iVar container

### DIFF
--- a/ivar/1.3.1/Dockerfile
+++ b/ivar/1.3.1/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:18.04
 ARG SAMTOOLSVER=1.12
 ARG HTSLIBVER=1.12
 ARG IVARVER=1.3.1
+ARG VIRALRECON=2.1
 
 LABEL base.image="ubuntu:18.04"
 LABEL dockerfile.version="2"
@@ -70,6 +71,15 @@ RUN cd root/ && \
   make && \
   make install && \
   mkdir /data
+  
+# nf-core/viralrecon
+RUN cd /tmp && \
+  wget https://github.com/nf-core/viralrecon/archive/refs/tags/${VIRALRECON}.tar.gz && \
+  tar -xzvf ${VIRALRECON}.tar.gz && \
+  rm -rf ${VIRALRECON}.tar.gz && \
+  chmod 755 viralrecon-${VIRALRECON}/bin/ivar_variants_to_vcf.py && \
+  cp viralrecon-${VIRALRECON}/bin/ivar_variants_to_vcf.py /usr/local/bin && \
+  rm -rf viralrecon-${VIRALRECON}/
 
 # set /data as working directory
 WORKDIR /data

--- a/ivar/1.3.1/Dockerfile
+++ b/ivar/1.3.1/Dockerfile
@@ -7,7 +7,7 @@ ARG IVARVER=1.3.1
 ARG VIRALRECON=2.1
 
 LABEL base.image="ubuntu:18.04"
-LABEL dockerfile.version="2"
+LABEL dockerfile.version="3"
 LABEL software="iVar"
 LABEL software.version="1.3.1"
 LABEL description="Computational package that contains functions broadly useful for viral amplicon-based sequencing."

--- a/ivar/1.3.1/Dockerfile
+++ b/ivar/1.3.1/Dockerfile
@@ -79,7 +79,8 @@ RUN cd /tmp && \
   rm -rf ${VIRALRECON}.tar.gz && \
   chmod 755 viralrecon-${VIRALRECON}/bin/ivar_variants_to_vcf.py && \
   cp viralrecon-${VIRALRECON}/bin/ivar_variants_to_vcf.py /usr/local/bin && \
-  rm -rf viralrecon-${VIRALRECON}/
+  rm -rf viralrecon-${VIRALRECON}/ && \
+  update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 # set /data as working directory
 WORKDIR /data

--- a/ivar/1.3.1/README.md
+++ b/ivar/1.3.1/README.md
@@ -5,6 +5,7 @@ Main tool : [iVar](https://andersen-lab.github.io/ivar/html/manualpage.html)
 Additional tools (required):
 * [HTSlib](https://github.com/samtools/htslib)
 * [samtools](http://www.htslib.org/)
+* [ivar_variants_to_vcf.py](https://github.com/nf-core/viralrecon/blob/master/bin/ivar_variants_to_vcf.py)
 
 # Example Usage
 
@@ -18,4 +19,7 @@ samtools mpileup -A -d 8000 -B -Q 0 --reference {reference.fasta} {bam} | \
 ```
 samtools mpileup -A -d 8000 -B -Q 0 --reference {reference.fasta} {bam} | \
       ivar consensus -t 0.6 -p {sample}.consensus -n N
+```
+```
+ivar_variants_to_vcf.py ivar-variants.tsv ivar-variants.vcf
 ```


### PR DESCRIPTION
The PR adds a script, [ivar_variants_to_vcf.py](https://github.com/nf-core/viralrecon/blob/dev/bin/ivar_variants_to_vcf.py), to convert the iVar variants in TSV format to VCF. The script is pulled from [nf-core/viralrecon](https://github.com/nf-core/viralrecon) v2.1 release.

`ivar_variants_to_vcf.py` had `/user/bin/env python` in it's shebang line, the container has `python3` in the path but not `python`. Rather than editing `ivar_variants_to_vcf.py`, I used `update-alternatives` to add `python` (just a symlink to `python3`).

Please let me know if there are any questions, or anything needed on my end.

### Example Usage
```
docker run --rm -u $(id -u):$(id -g) -v ${PWD}:/data ivar:1.3.1 ivar_variants_to_vcf.py 20154160_S5_L001.variants.tsv 20154160_S5_L001.variants.vcf
```

Attaching inputs/outputs (w/ .txt extension to make GitHub happy)
[20154160_S5_L001.variants.vcf.txt](https://github.com/StaPH-B/docker-builds/files/6785952/20154160_S5_L001.variants.vcf.txt)
[20154160_S5_L001.variants.tsv.txt](https://github.com/StaPH-B/docker-builds/files/6785953/20154160_S5_L001.variants.tsv.txt)
