### PR TITLE
add TSV to VCF script to iVar Titan container

### DIFF
--- a/ivar/1.3.1_Titan/Dockerfile
+++ b/ivar/1.3.1_Titan/Dockerfile
@@ -5,9 +5,10 @@ ARG SAMTOOLSVER=1.10
 ARG HTSLIBVER=1.11
 ARG IVARVER=1.3.1
 ARG BWASVER=0.7.17
+ARG VIRALRECON=2.1
 
 LABEL base.image="ubuntu:18.04"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="iVar"
 LABEL software.version="1.3.1"
 LABEL description="Computational package that contains functions broadly useful for viral amplicon-based sequencing."
@@ -97,6 +98,16 @@ ENV PATH="/bwa/bwa-0.7.17:${PATH}"
 RUN for artic_version in "V1" "V2" "V3" ; do \
     bwa index /artic-ncov2019/primer_schemes/nCoV-2019/$artic_version/nCoV-2019.reference.fasta && \
     samtools faidx /artic-ncov2019/primer_schemes/nCoV-2019/$artic_version/nCoV-2019.reference.fasta ; done
+
+# nf-core/viralrecon
+RUN cd /tmp && \
+  wget https://github.com/nf-core/viralrecon/archive/refs/tags/${VIRALRECON}.tar.gz && \
+  tar -xzvf ${VIRALRECON}.tar.gz && \
+  rm -rf ${VIRALRECON}.tar.gz && \
+  chmod 755 viralrecon-${VIRALRECON}/bin/ivar_variants_to_vcf.py && \
+  cp viralrecon-${VIRALRECON}/bin/ivar_variants_to_vcf.py /usr/local/bin && \
+  rm -rf viralrecon-${VIRALRECON}/ && \
+  update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 # set /data as working directory
 WORKDIR /data

--- a/ivar/1.3.1_Titan/Readme.md
+++ b/ivar/1.3.1_Titan/Readme.md
@@ -6,6 +6,7 @@ Additional tools (required):
 * [HTSlib](https://github.com/samtools/htslib)
 * [samtools](http://www.htslib.org/)
 * [bwa](http://bio-bwa.sourceforge.net/)
+* [ivar_variants_to_vcf.py](https://github.com/nf-core/viralrecon/blob/master/bin/ivar_variants_to_vcf.py)
 
 Also includes the 
 * [artic primers](https://github.com/artic-network/artic-ncov2019.git) as they were on 2021-05-06 (7e359dae37d894b40ae7e35c3582f14244ef4d36)
@@ -24,4 +25,7 @@ samtools mpileup -A -d 8000 -B -Q 0 --reference {reference.fasta} {bam} | \
 ```
 samtools mpileup -A -d 8000 -B -Q 0 --reference {reference.fasta} {bam} | \
       ivar consensus -t 0.6 -p {sample}.consensus -n N
+```
+```
+ivar_variants_to_vcf.py ivar-variants.tsv ivar-variants.vcf
 ```


### PR DESCRIPTION
This PR replaces https://github.com/StaPH-B/docker-builds/pull/224 (see for previous discussion) so as to only affect the ivar-titan container, not the main one.

The PR adds a script, [ivar_variants_to_vcf.py](https://github.com/nf-core/viralrecon/blob/dev/bin/ivar_variants_to_vcf.py), to convert the iVar variants in TSV format to VCF. The script is pulled from [nf-core/viralrecon](https://github.com/nf-core/viralrecon) v2.1 release.

`ivar_variants_to_vcf.py` had `/user/bin/env python` in it's shebang line, the container has `python3` in the path but not `python`. Rather than editing `ivar_variants_to_vcf.py`, I used `update-alternatives` to add `python` (just a symlink to `python3`).

Please let me know if there are any questions, or anything needed on my end.

### Example Usage
```
docker run --rm -u $(id -u):$(id -g) -v ${PWD}:/data ivar:1.3.1-titan ivar_variants_to_vcf.py 20154160_S5_L001.variants.tsv 20154160_S5_L001.variants.vcf
```

Attaching inputs/outputs (w/ .txt extension to make GitHub happy)
[20154160_S5_L001.variants.vcf.txt](https://github.com/StaPH-B/docker-builds/files/6785952/20154160_S5_L001.variants.vcf.txt)
[20154160_S5_L001.variants.tsv.txt](https://github.com/StaPH-B/docker-builds/files/6785953/20154160_S5_L001.variants.tsv.txt)