### PR TITLE
Add apt dependencies of histogram script to Filtlong Dockerfile

### DIFF
--- a/filtlong/0.2.1/Dockerfile
+++ b/filtlong/0.2.1/Dockerfile
@@ -32,6 +32,7 @@ RUN wget https://github.com/rrwick/Filtlong/archive/v${FILTLONG_VER}.tar.gz && \
  rm -r v${FILTLONG_VER}.tar.gz && \
  cd Filtlong-${FILTLONG_VER}/ && \
  make -j && \
+ sed -i 's/\$hist/\$hist --dot "*"/g' scripts/read_info_histograms.sh && \
  mkdir /data
 
 # required for singularity compatibility; update PATH

--- a/filtlong/0.2.1/Dockerfile
+++ b/filtlong/0.2.1/Dockerfile
@@ -37,6 +37,6 @@ RUN wget https://github.com/rrwick/Filtlong/archive/v${FILTLONG_VER}.tar.gz && \
 
 # required for singularity compatibility; update PATH
 ENV LC_ALL=C \
- PATH="${PATH}:/Filtlong-${FILTLONG_VER}/bin"
+ PATH="${PATH}:/Filtlong-${FILTLONG_VER}/bin:/Filtlong-${FILTLONG_VER}/scripts"
 
 WORKDIR /data

--- a/filtlong/0.2.1/Dockerfile
+++ b/filtlong/0.2.1/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
  pigz \
  less \
  bc && \
+ update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
 # install filtlong; make /data

--- a/filtlong/0.2.1/Dockerfile
+++ b/filtlong/0.2.1/Dockerfile
@@ -10,6 +10,8 @@ LABEL software.version="0.2.1"
 LABEL description="Filter long reads by quality and length. Can use ILMN reads as reference."
 LABEL website="https://github.com/rrwick/Filtlong"
 LABEL license="https://github.com/rrwick/Filtlong/blob/master/LICENSE"
+LABEL maintainer="Curtis Kapsak"
+LABEL maintainer.email="kapsakcj@gmail.com"
 LABEL maintainer="Thomas A. Christensen II"
 LABEL maintainer.email="25492070+MillironX@users.noreply.github.com"
 

--- a/filtlong/0.2.1/Dockerfile
+++ b/filtlong/0.2.1/Dockerfile
@@ -4,14 +4,14 @@ FROM ubuntu:xenial
 ARG FILTLONG_VER=0.2.1
 
 LABEL base.image="ubuntu:xenial"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="Filtlong"
 LABEL software.version="0.2.1"
 LABEL description="Filter long reads by quality and length. Can use ILMN reads as reference."
 LABEL website="https://github.com/rrwick/Filtlong"
 LABEL license="https://github.com/rrwick/Filtlong/blob/master/LICENSE"
-LABEL maintainer="Curtis Kapsak"
-LABEL maintainer.email="kapsakcj@gmail.com"
+LABEL maintainer="Thomas A. Christensen II"
+LABEL maintainer.email="25492070+MillironX@users.noreply.github.com"
 
 # install deps; cleanup apt garbage
 RUN apt-get update && apt-get install -y \

--- a/filtlong/0.2.1/Dockerfile
+++ b/filtlong/0.2.1/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update && apt-get install -y \
  zlib1g-dev \
  make \
  python3 \
- pigz && \
+ pigz \
+ less \
+ bc && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
 # install filtlong; make /data


### PR DESCRIPTION
As noted in #258, the current Filtlong image is not compatible with its
own included `read_info_histograms.sh` script. Fixes that by

- Adding `apt-get` dependencies
- Setting `python3` as alternative to `python`
- Editing out incompatible Unicode characters

and adds `read_info_histograms.sh` to `PATH` for easy access.

Also includes updated metadata tags `dockerfile.version`, `maintainer`,
and `maintainer.email`. I wasn't sure what the policy was on deciding who
was 'maintainer' of each image, but thought that I should update that
since I was the last person to edit the Dockerfile.

Tests
-----

- [x] Verify image builds:
    ```shellsession
    $ docker build -t millironx/filtlong:0.2.1 filtlong/0.2.1
    ...
    Successfully built f065fab56ef5
    Successfully tagged millironx/filtlong:0.2.1
    ```
- [x] Verify version number:
    ```shellsession
    $ docker run -it millironx/filtlong:0.2.1
    root@569011143ca1# filtlong --version
    Filtlong v0.2.1
    ```
- [x] Verify output:
    ```shellsession
    $ docker run -v /data:/data -it millironx/filtlong:0.2.1
    root@569011143ca1# filtlong --min_length 1000 sample.fastq.gz | gzip > sample.trimmed.gz
    
    Scoring long reads
      123005 reads (49995147 bp)

    Outputting passed long reads

    root@569011143ca1# read_info_histograms.sh sample.fastq.gz
    
    READ SET SUMMARY
    ----------------
    number of reads: 123005
    number of bases: 49995147
    N50 read length: 467
    
    
    READ LENGTHS
    ------------
    Each * represents 157,555 bases
       0 -  114 [     1,398]: 
     114 -  228 [ 5,790,956]: ************************************
     228 -  342 [11,028,866]: **********************************************************************
     ...
     ```