### PR TITLE
added kraken 1.1.1 to roary 3.13.0 dockerfile

### DIFF
--- a/roary/3.13.0/Dockerfile
+++ b/roary/3.13.0/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal
 
 # metadata
 LABEL base.image="ubuntu:focal"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="Roary"
 LABEL software.version="3.13.0"
 LABEL description="Rapid large-scale prokaryotic pan genome analysis"
@@ -15,11 +15,38 @@ LABEL maintainer.email="kapsakcj@gmail.com"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # install roary 3.13.0 via apt; cleanup apt garbage; make /data and /kraken_db
-RUN apt-get update && apt-get install -y --no-install-recommends roary && \
+RUN apt-get update && apt-get install -y --no-install-recommends roary \
+ wget \
+ zlib1g-dev \
+ make \
+ g++ \
+ rsync \
+ cpanminus && \
  apt-get autoclean && \
  rm -rf /var/lib/apt/lists/* && \
  mkdir /data /kraken_db
 
+# this perl module and rsync required for kraken-build
+RUN cpanm --force --notest Getopt::Std
+
+# DL Jellyfish, unpack, and install
+RUN wget https://github.com/gmarcais/Jellyfish/releases/download/v1.1.12/jellyfish-1.1.12.tar.gz && \
+ tar -zxf jellyfish-1.1.12.tar.gz && \
+ rm -rf jellyfish-1.1.12.tar.gz && \
+ cd jellyfish-1.1.12 && \
+ ./configure --prefix=/opt/ && \
+ make -j 4 && \
+ make install
+
+# DL Kraken v1.1.1, unpack, and install
+RUN wget https://github.com/DerrickWood/kraken/archive/v1.1.1.tar.gz && \
+  tar -xzf v1.1.1.tar.gz && \
+  rm -rf v1.1.1.tar.gz && \
+  cd kraken-1.1.1 && \
+  mkdir /opt/kraken && \
+  ./install_kraken.sh /opt/kraken/
+
 WORKDIR /data
-# set perl locale settings
-ENV LC_ALL=C
+# set perl locale settings and PATH
+ENV LC_ALL=C.UTF-8 \
+ PATH="$PATH:/opt/kraken:/opt/bin"


### PR DESCRIPTION
To address #254 

Docker image is available temporarily on dockerhub under my personal repo `kapsakcj/roary:3.13.0-plus-kraken`

https://hub.docker.com/r/kapsakcj/roary/tags?page=1&ordering=last_updated

@erinyoung Can you try it out and let me know how it goes? Would appreciate a quick test (I don't have any data handy to do this), especially run via `singularity`.

One thing to note is that I'm trying something new. I've set `LC_ALL=C.UTF-8` instead of the usual `LC_ALL=C`. I've read that this will prevent headaches down the road. Something to do with encoding or something....

If you have perl issues, we can revert back to LC_ALL=C before merging this PR and rebuilding the `staphb/roary:3.13.0` docker image