### PR TITLE
Adding templates to PR and Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,32 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What container were you trying to use, and how were you attempting to use it?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/new_container.yaml
+++ b/.github/ISSUE_TEMPLATE/new_container.yaml
@@ -1,0 +1,26 @@
+name: Container Request
+description: Request a new container
+title: "[Container Request]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your request. We always want to hear about new tools!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-needed
+    attributes:
+      label: What tool are you looking for and why?
+      description: Also tell us if it is already available on dockerhub
+      placeholder: Tell us what you see!
+      value: "I need to use X for Y!"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/repo_request.yaml
+++ b/.github/ISSUE_TEMPLATE/repo_request.yaml
@@ -1,0 +1,25 @@
+name: Repo Request
+description: Requests for functionality for this github repo including github actions
+title: "[Repo Request]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to make this repo better!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What functionality is this repo missing?
+      description: Also tell us, what did you expect to happen?
+      value: "This github repo is awesome, but..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/update_container.yaml
+++ b/.github/ISSUE_TEMPLATE/update_container.yaml
@@ -1,0 +1,26 @@
+name: Update Container
+description: Request an update for an existing container
+title: "[Request An Update]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for requesting additional functionality for these containers!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What container needs an update?
+      description: Also tell us why, please.
+      placeholder: Tell us what container needs an update!
+      value: "I know all of these containers are awesome, but..."
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,74 @@
+<!--
+Thank your for contributing to the Staph-B community!
+Please fill in the appropriate checklist below and delete whatever is not relevant.
+
+These recommendations are not meant as a means to keep people from contributing. 
+If you need assistance with the following measures, submit your pull request anyway, and we will work with you...
+Or you can contact us beforehand via slack or by sumitting a pull request https://github.com/StaPH-B/docker-builds/issues
+
+Documentation on how to contribute can be found at https://staphb.org/docker-builds/contribute/
+Documentation for how to create a Dockerfile can be found at https://staph-b.github.io/docker-builds/make_containers
+A recommended Dockerfile template can be found at https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile
+
+To reiterate common comments in pull requests : 
+
+Recommended ways to denote software versions
+ARG SOFTWARENAME_VER="1.0.0"
+
+Recommended labels:
+LABEL base.image="ubuntu:focal"
+LABEL dockerfile.version="1"
+LABEL software="SoftwareName"
+LABEL software.version=$SOFTWARENAME_VER
+LABEL description="This software does X, Y, AND Z!"
+LABEL website="https://github.com/StaPH-B/docker-builds"
+LABEL license="https://github.com/StaPH-B/docker-builds/blob/master/LICENSE"
+LABEL maintainer="FirstName LastName"
+LABEL maintainer.email="my.email@email.com"
+-->
+
+
+- [ ] This comment contains a description of what is in the pull request.
+
+
+<!-- If this PR is to add a dockerfile for a new tool -->
+- [ ] Build your own docker image using a Dockerfile
+  - [ ] Directory structure should be name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. spades/3.12.0/Dockerfile)
+  - [ ] Includes the recommended LABELS
+- [ ] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
+- [ ] Edit main README.md
+- [ ] Edit Program_Licenses.md
+- [ ] Create a simple container-specific README.md in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
+- [ ] Write a GitHub actions workflow
+  - [ ] Should be located in .github/workflows/ and named test-<tool>.yml (i.e. .github/workflows/test-spades.yml)
+  - [ ] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
+  - [ ] Have successfully run the workflow "Test <program name> image" in your forked repository
+
+<!-- If this PR is to add a new version of a tool that already has a dockerfile -->
+- [ ] Build your own docker image using a Dockerfile
+  - [ ] Directory structure should be name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. spades/3.12.0/Dockerfile)
+  - [ ] Includes the recommended LABELS
+- [ ] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
+- [ ] Edit main README.md
+- [ ] Ensure tool is listed in Program_Licenses.md
+- [ ] Create a simple container-specific README.md in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
+- [ ] Update GitHub actions workflow if needed
+- [ ] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
+- [ ] Have successfully run the workflow "Test <program name> image" in your forked repository
+
+<!-- If this PR is to adjust an existing dockerfile  -->
+- [ ] Build your own docker image using a Dockerfile
+  - [ ] Includes the recommended LABELS
+- [ ] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
+- [ ] Ensure tool is listed in Program_Licenses.md
+- [ ] Ensure a simple container-specific README.md exists in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
+- [ ] Update GitHub actions workflow if needed
+- [ ] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
+- [ ] Have successfully run the workflow "Test <program name> image" in your forked repository
+
+<!-- If this PR is to adjust an existing GitHub actions workflow or to create one -->
+- [ ] Update relevant GitHub actions workflow files
+- [ ] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
+- [ ] Have successfully run the workflow "Test <program name> image" in your forked repository
+
+<!-- If this PR is for something else, please add extra descriptions -->


### PR DESCRIPTION
1) Adding a bit of polish onto the Issues. 

Issues are divided into four general categories:
- bug reports
- new container requests
- container update requests
- github repo functionality requests (like github actions, etc)

These each have their own yaml file in .github/ISSUE_TEMPLATE

You can test out what this looks like on my forked repo : https://github.com/erinyoung/docker-builds

2) Adding clarity to pull requests

I followed the lead of a different repo that relies heavily on community engagement : [multiqc](https://github.com/ewels/MultiQC/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

When I contributed to multiqc back in the day, the pull request came with a little checklist that made it easier for both the contributor and reviewer. I created a similar checklist with .github/PULL_REQUEST_TEMPLATE.md. This opens up a comment at the beginning of the pull request that the contributor can edit.

In theory, we could create different pull request templates as well by creating yaml files in a .github/PULL_REQUEST_TEMPLATE directory, but this is kind of hard to test.