### PR TITLE
adding htslib 1.14

### DIFF
--- a/Program_Licenses.md
+++ b/Program_Licenses.md
@@ -34,6 +34,7 @@ The licenses of the open-source software that is contained in these Docker image
 | GAMBIT | GNU aGPLv3 | https://github.com/hesslab-gambit/gambit/blob/master/LICENSE |
 | GAMMA | Apache 2.0? | Not clearly indicated on: https://github.com/rastanton/GAMMA/ <br> Bioconda lists Apache 2.0: https://bioconda.github.io/recipes/gamma/README.html?highlight=gamma|
 | Hmmer | BSD-3 | http://eddylab.org/software/hmmer/Userguide.pdf |
+| htslib | MIT | https://github.com/samtools/htslib/blob/develop/LICENSE |
 | iqtree | GNU GPLv2 | https://github.com/Cibiv/IQ-TREE/blob/master/LICENSE |
 | iqtree2 | GNU GPLv2 | https://github.com/iqtree/iqtree2/blob/master/LICENSE |
 | iVar | GNU GPLv3 | https://github.com/andersen-lab/ivar/blob/master/LICENSE |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To learn more about the docker pull rate limits and the open source software pro
 | [GAMBIT](https://hub.docker.com/r/staphb/gambit) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/gambit.svg?style=popout)](https://hub.docker.com/r/staphb/gambit) | <ul><li>0.3.0</li></ul> | https://github.com/hesslab-gambit/gambit |
 | [GAMMA](https://hub.docker.com/r/staphb/gamma) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/gamma.svg?style=popout)](https://hub.docker.com/r/staphb/gamma) | <ul><li>1.4</li></ul> | https://github.com/rastanton/GAMMA/ |
 | [hmmer](https://hub.docker.com/r/staphb/hmmer) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/hmmer.svg?style=popout)](https://hub.docker.com/r/staphb/hmmer) | <ul><li>3.3</li></ul> | http://hmmer.org/ |
+| [htslib](https://hub.docker.com/r/staphb/htslib) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/htslib.svg?style=popout)](https://hub.docker.com/r/staphb/htslib) | <ul><li>1.14</li></ul> | https://www.htslib.org/ |
 | [iqtree](https://hub.docker.com/r/staphb/iqtree/) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/iqtree.svg?style=popout)](https://hub.docker.com/r/staphb/iqtree) | <ul><li>1.6.7</li></ul> | http://www.iqtree.org/ |
 | [iqtree2](https://hub.docker.com/r/staphb/iqtree2/) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/iqtree2.svg?style=popout)](https://hub.docker.com/r/staphb/iqtree2) | <ul><li>2.1.2</li></ul> | http://www.iqtree.org/ |
 | [iVar](https://hub.docker.com/r/staphb/ivar/) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/ivar.svg?style=popout)](https://hub.docker.com/r/staphb/ivar) | <ul><li>1.1</li><li>1.1 (+SARS-CoV2 reference)</li><li>1.2.1</li><li>1.2.1 (+SC2 ref)</li><li>1.2.2 (+SC2 ref and artic bedfiles)</li><li>1.3</li><li>1.3.1</li></ul> | https://github.com/andersen-lab/ivar |
@@ -81,7 +82,7 @@ To learn more about the docker pull rate limits and the open source software pro
 | [medaka](https://hub.docker.com/r/staphb/medaka) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/medaka.svg?style=popout)](https://hub.docker.com/r/staphb/medaka) | <ul><li>0.8.1</li><li>1.0.1</li><li>1.2.0</li></ul> | https://github.com/nanoporetech/medaka |
 | [metaphlan](https://hub.docker.com/r/staphb/metaphlan) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/metaphlan.svg?style=popout)](https://hub.docker.com/r/staphb/metaphlan) | <ul><li>3.0.3-no-db (no database)</li><li> 3.0.3 (~3GB db) | https://github.com/biobakery/MetaPhlAn/tree/3.0 |
 | [minimap2](https://hub.docker.com/r/staphb/minimap2) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/minimap2.svg?style=popout)](https://hub.docker.com/r/staphb/minimap2) | <ul><li>2.17</li><li>2.18</li><li>2.21</li><li>2.22</li><li>2.23</li><li>2.24</li></ul> | https://github.com/lh3/minimap2 |
-| [minipolish](https://hub.docker.com/r/staphb/minipolish) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/minipolish.svg?style=popout)](https://hub.docker.com/r/staphb/minipolish) | <ul><li>0.1.3</li></ul> | https://github.com/rrwick/Minipolish | 
+| [minipolish](https://hub.docker.com/r/staphb/minipolish) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/minipolish.svg?style=popout)](https://hub.docker.com/r/staphb/minipolish) | <ul><li>0.1.3</li></ul> | https://github.com/rrwick/Minipolish |
 | [mlst](https://hub.docker.com/r/staphb/mlst) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/mlst.svg?style=popout)](https://hub.docker.com/r/staphb/mlst) | <ul><li>2.16.2</li><li>2.17.6</li><li>2.19.0</li></ul> | https://github.com/tseemann/mlst |
 | [Mugsy](https://hub.docker.com/r/staphb/mugsy) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/mugsy.svg?style=popout)](https://hub.docker.com/r/staphb/mugsy) | <ul><li>1r2.3</li></ul> | http://mugsy.sourceforge.net/ |
 | [MultiQC](https://hub.docker.com/r/staphb/multiqc) <br/> [![docker pulls](https://img.shields.io/docker/pulls/staphb/multiqc.svg?style=popout)](https://hub.docker.com/r/staphb/multiqc) | <ul><li>1.7</li><li>1.8</li></ul> | https://github.com/ewels/MultiQC |
@@ -150,7 +151,7 @@ Each Dockerfile lists the author(s)/maintainer(s) as a metadata `LABEL`, but the
   * [@andersgs](https://github.com/andersgs)
   * [@logan-fink](https://github.com/logan-fink)
   * [@tgallagh](https://github.com/tgallagh)
-  * Kelly Oakeson
+  * [@koakeson](https://github.com/koakeson)
   * [@joacjo](https://github.com/joacjo)
   * [@rpetit3](https://github.com/rpetit3/)
   * [@jvhagey](https://github.com/jvhagey)

--- a/htslib/1.14/Dockerfile
+++ b/htslib/1.14/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:xenial
+
+# for easy upgrade later. ARG variables only persist during build time
+ARG HTSLIBVER="1.14"
+
+LABEL base.image="ubuntu:xenial"
+LABEL dockerfile.version="1"
+LABEL software="htslib"
+LABEL software.version="1.14"
+LABEL description="A C library for reading/writing high-throughput sequencing data"
+LABEL website="https://github.com/samtools/htslib"
+LABEL license="https://github.com/samtools/htslib/blob/develop/LICENSE"
+LABEL maintainer="Erin Young"
+LABEL maintainer.email="eriny@utah.gov"
+
+# install dependencies, cleanup apt garbage
+# It's helpful when they're all listed on https://github.com/samtools/htslib/blob/develop/INSTALL
+RUN apt-get update && apt-get install --no-install-recommends -y \
+ wget \
+ ca-certificates \
+ make \
+ bzip2 \
+ autoconf \
+ automake \
+ make \
+ gcc \
+ perl \
+ zlib1g-dev \
+ libbz2-dev \
+ liblzma-dev \
+ libcurl4-gnutls-dev \
+ libssl-dev && \
+ rm -rf /var/lib/apt/lists/* && apt-get autoclean
+
+# get htslib and make /data
+RUN wget https://github.com/samtools/htslib/releases/download/${HTSLIBVER}/htslib-${HTSLIBVER}.tar.bz2 && \
+ tar -vxjf htslib-${HTSLIBVER}.tar.bz2 && \
+ rm htslib-${HTSLIBVER}.tar.bz2 && \
+ cd htslib-${HTSLIBVER} && \
+ make && \
+ make install && \
+ mkdir /data
+
+# set $PATH (honestly unnecessary here, lol) and locale settings for singularity compatibility
+ENV PATH="$PATH" \
+ LC_ALL=C
+
+# set working directory
+WORKDIR /data
+
+# Testing the install
+RUN cd /htslib-1.14/test && \
+  perl /htslib-1.14/test/test.pl && \
+  rm *tmp*

--- a/htslib/1.14/README.md
+++ b/htslib/1.14/README.md
@@ -1,0 +1,13 @@
+# htslib container
+
+Main tool : [htslib](https://www.htslib.org/)
+
+
+# Example Usage
+
+```
+# compresses sample.fastq to sample.fastq.gz
+bgzip sample.fastq
+```
+
+Better documentation can be found at [http://www.htslib.org](http://www.htslib.org/doc/#manual-pages)


### PR DESCRIPTION
We have samtools and bcftools, here's the round out everything
(plus, I need bgzip because medaka won't use fastq files compressed with gzip)

- [X] This comment contains a description of what is in the pull request.
- [X] Build your own docker image using a Dockerfile
  - [X] Directory structure should be name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. spades/3.12.0/Dockerfile)
  - [X] Includes the recommended LABELS
- [X] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
- [X] Edit main README.md
- [X] Edit Program_Licenses.md
- [X] Create a simple container-specific README.md in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)

- [ ] Write a GitHub actions workflow
  - [ ] Should be located in .github/workflows/ and named test-<tool>.yml (i.e. .github/workflows/test-spades.yml)
  - [ ] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
  - [] Have successfully run the workflow "Test <program name> image" in your forked repository

htslib has a prebuilt testing capacity, so I included that and then I remove the test files (lines 51-54 in the Dockerfile). Is that good enough?