### PR TITLE
fix typo in workflow input repository name

### DIFF
--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -17,7 +17,7 @@ on:
         default: Dockerfile
         required: false
         type: string
-      repositoy_name:
+      repository_name:
         default: staphb
         required: false
         type: string

--- a/.github/workflows/run-singularity.yml
+++ b/.github/workflows/run-singularity.yml
@@ -8,7 +8,7 @@ on:
       image_name:
         required: true
         type: string
-      repositoy_name:
+      repository_name:
         default: staphb
         required: false
         type: string


### PR DESCRIPTION
- [x] This comment contains a description of what is in the pull request.

This PR is to fix a typo in an input variable for two of the called GitHub actions workflows. 

<!-- If this PR is to adjust an existing GitHub actions workflow or to create one -->
- [x] Update relevant GitHub actions workflow files

Changed "repositoy_name" to "repository_name". This variable has not been used in any caller workflows because it has a default ("staphb"), so it only has to be fixed in these 2 files. I'd like to fix it because I want to use it to keep deploying to my own Docker Hub from my fork of this repo.

- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)

NA.

- [x] Have successfully run the workflow "Test <program name> image" in your forked repository

NA.
