### PR TITLE
fix 2 more instances of workflow typo

### DIFF
--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -73,7 +73,7 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache-${{ inputs.cache }}
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ inputs.cache }}-new # mode=max means export layers from all stage to cache
-          tags: ${{ inputs.repositoy_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
+          tags: ${{ inputs.repository_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
 
       - name: Move cache # apparently prevents the cache from growing in size forever
         run: |

--- a/.github/workflows/run-singularity.yml
+++ b/.github/workflows/run-singularity.yml
@@ -31,4 +31,4 @@ jobs:
           singularity-version: 3.8.3
 
       - name: Run a singularity container
-        run: singularity run docker://${{ inputs.repositoy_name }}/${{ inputs.image_name }} ${{ inputs.command }}
+        run: singularity run docker://${{ inputs.repository_name }}/${{ inputs.image_name }} ${{ inputs.command }}


### PR DESCRIPTION
- [x] This comment contains a description of what is in the pull request.

I missed two instances of the typo where this parameter is actually used, grr.

- [x] Update relevant GitHub actions workflow files
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)

NA.

- [x] Have successfully run the workflow "Test <program name> image" in your forked repository

I can't think how to do this given the workflow references are to StaPH-B/docker-builds repo :/ 
