### PR TITLE
update GH actions workflows & pangolin PATH issue

### DIFF
--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -70,8 +70,9 @@ jobs:
       - name: Login to Quay
         uses: docker/login-action@v1
         with:
+          registry: quay.io
           username: ${{ secrets.quay_username }}
-          password: ${{ secrets.quay_access_token }}
+          password: ${{ secrets.quay_robot_token }}
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -11,7 +11,7 @@ on:
         required: true
       quay_username:
         required: true
-      quay_access_token:
+      quay_robot_token:
         required: true
     inputs:
       path_to_context:

--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -63,6 +63,12 @@ jobs:
           username: ${{ secrets.docker_username }}
           password: ${{ secrets.docker_access_token }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.quay_username }}
+          password: ${{ secrets.quay_access_token }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -73,7 +79,11 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache-${{ inputs.cache }}
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ inputs.cache }}-new # mode=max means export layers from all stage to cache
-          tags: ${{ inputs.repository_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
+          tags: | # pushing to both dockerhub and quay for both latest and user-defined inputs.tag
+            ${{ inputs.repository_name }}/${{ inputs.container_name }}:latest
+            ${{ inputs.repository_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
+            quay.io/${{ inputs.repository_name }}/${{ inputs.container_name }}:latest
+            quay.io/${{ inputs.repository_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
 
       - name: Move cache # apparently prevents the cache from growing in size forever
         run: |

--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -9,6 +9,10 @@ on:
         required: true
       docker_access_token:
         required: true
+      quay_username:
+        required: true
+      quay_access_token:
+        required: true
     inputs:
       path_to_context:
         required: true

--- a/.github/workflows/deploy-pangolin3.1.20-slim.yml
+++ b/.github/workflows/deploy-pangolin3.1.20-slim.yml
@@ -8,7 +8,7 @@ on: workflow_dispatch
 jobs:
 
   build-to-test:
-    uses: StaPH-B/docker-builds/.github/workflows/build-to-test.yml@master
+    uses: ${{ github.repository_owner }}/docker-builds/.github/workflows/build-to-test.yml@master
     with:
       path_to_context: "./pangolin/3.1.20-slim/"
       dockerfile_name: "Dockerfile"
@@ -16,7 +16,7 @@ jobs:
 
   build-to-deploy:
     needs: build-to-test  # this jobs needs to run serially, after testing succeeds
-    uses: StaPH-B/docker-builds/.github/workflows/build-to-deploy.yml@master
+    uses: ${{ github.repository_owner }}/docker-builds/.github/workflows/build-to-deploy.yml@master
     secrets:
       docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
 
   run-singularity:
     needs: build-to-deploy  # test singularity run on newly pushed Docker image
-    uses: StaPH-B/docker-builds/.github/workflows/run-singularity.yml@master
+    uses: ${{ github.repository_owner }}/docker-builds/.github/workflows/run-singularity.yml@master
     with:
       image_name: "pangolin:3.1.20-pangolearn-2022-02-28"

--- a/.github/workflows/deploy-pangolin3.1.20-slim.yml
+++ b/.github/workflows/deploy-pangolin3.1.20-slim.yml
@@ -26,7 +26,7 @@ jobs:
       cache: "pangolin"
       container_name: "pangolin"
       tag: |
-        3.1.20-pangolearn-2022-02-28
+        3.1.20-pangolearn-2022-02-28,
         latest
 
   run-singularity:

--- a/.github/workflows/deploy-pangolin3.1.20-slim.yml
+++ b/.github/workflows/deploy-pangolin3.1.20-slim.yml
@@ -8,7 +8,7 @@ on: workflow_dispatch
 jobs:
 
   build-to-test:
-    uses: ./docker-builds/.github/workflows/build-to-test.yml@master
+    uses: ./.github/workflows/build-to-test.yml
     with:
       path_to_context: "./pangolin/3.1.20-slim/"
       dockerfile_name: "Dockerfile"
@@ -16,7 +16,7 @@ jobs:
 
   build-to-deploy:
     needs: build-to-test  # this jobs needs to run serially, after testing succeeds
-    uses: ./docker-builds/.github/workflows/build-to-deploy.yml@master
+    uses: ./.github/workflows/build-to-deploy.yml
     secrets:
       docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
 
   run-singularity:
     needs: build-to-deploy  # test singularity run on newly pushed Docker image
-    uses: ./docker-builds/.github/workflows/run-singularity.yml@master
+    uses: ./.github/workflows/run-singularity.yml
     with:
       image_name: "pangolin:3.1.20-pangolearn-2022-02-28"

--- a/.github/workflows/deploy-pangolin3.1.20-slim.yml
+++ b/.github/workflows/deploy-pangolin3.1.20-slim.yml
@@ -20,6 +20,8 @@ jobs:
     secrets:
       docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      quay_username: ${{ secrets.quay_username }}
+      quay_robot_token: ${{ secrets.quay_robot_token }}
     with:
       path_to_context: "./pangolin/3.1.20-slim/"
       dockerfile_name: "Dockerfile"

--- a/.github/workflows/deploy-pangolin3.1.20-slim.yml
+++ b/.github/workflows/deploy-pangolin3.1.20-slim.yml
@@ -8,7 +8,7 @@ on: workflow_dispatch
 jobs:
 
   build-to-test:
-    uses: ${{ github.repository_owner }}/docker-builds/.github/workflows/build-to-test.yml@master
+    uses: ./docker-builds/.github/workflows/build-to-test.yml@master
     with:
       path_to_context: "./pangolin/3.1.20-slim/"
       dockerfile_name: "Dockerfile"
@@ -16,7 +16,7 @@ jobs:
 
   build-to-deploy:
     needs: build-to-test  # this jobs needs to run serially, after testing succeeds
-    uses: ${{ github.repository_owner }}/docker-builds/.github/workflows/build-to-deploy.yml@master
+    uses: ./docker-builds/.github/workflows/build-to-deploy.yml@master
     secrets:
       docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -29,6 +29,6 @@ jobs:
 
   run-singularity:
     needs: build-to-deploy  # test singularity run on newly pushed Docker image
-    uses: ${{ github.repository_owner }}/docker-builds/.github/workflows/run-singularity.yml@master
+    uses: ./docker-builds/.github/workflows/run-singularity.yml@master
     with:
       image_name: "pangolin:3.1.20-pangolearn-2022-02-28"

--- a/.github/workflows/deploy-pangolin3.1.20-slim.yml
+++ b/.github/workflows/deploy-pangolin3.1.20-slim.yml
@@ -25,9 +25,7 @@ jobs:
       dockerfile_name: "Dockerfile"
       cache: "pangolin"
       container_name: "pangolin"
-      tag: |
-        3.1.20-pangolearn-2022-02-28,
-        latest
+      tag: "3.1.20-pangolearn-2022-02-28" # only specifying one tag since build-to-deploy assumes pushing "latest" tag
 
   run-singularity:
     needs: build-to-deploy  # test singularity run on newly pushed Docker image

--- a/pangolin/3.1.20-slim/Dockerfile
+++ b/pangolin/3.1.20-slim/Dockerfile
@@ -66,6 +66,9 @@ RUN pip install . && \
 
 WORKDIR /data
 
+# hardcode pangolin executable into the PATH variable
+ENV PATH="$PATH:/opt/conda/envs/pangolin/bin/"
+
 # new base for testing
 FROM app as test
 

--- a/pangolin/3.1.20-slim/Dockerfile
+++ b/pangolin/3.1.20-slim/Dockerfile
@@ -31,7 +31,8 @@ LABEL maintainer1.email="kapsakcj@gmail.com"
 RUN apt-get update && apt-get install -y --no-install-recommends \
  wget \
  ca-certificates \
- git && \
+ git \
+ procps && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
 # get the pangolin repo


### PR DESCRIPTION
This PR adds or edits 3 things:

#### 1. Improves upon the existing GH Actions workflow `.github/workflows/build-to-deploy.yml`
  * `quay_username` and `quay_robot_token` are now required. I have saved these secrets in our repo already.
  * added a job for logging in to quay, directly following logging into dockerhub
  * edited to allow for pushing the docker images to multiple repos (quay and dockerhub) as well as push multiple docker image tags ( `latest` and user-defined tag, so for example `3.1.20-pangolearn-2022-02-28` for `staphb/pangolin`).
    * This user defined tag is set in line 30 of `.github/workflows/deploy-pangolin3.1.20-slim.yml`. Other maintainers can follow this pattern when writing their own `deploy-<program-name>-<version>.yml` workflows


#### 2. Improves upon the existing GH Actions workflow `.github/workflows/deploy-pangolin3.1.20-slim.yml`
  * Now calls the required inputs for pushing to quay (`quay_username` and `quay_robot_token`)
  * Only specifies one docker image tag instead of multiple since this is handled in the `build-to-deploy.yml`. Example: `3.1.20-pangolearn-2022-02-28`
  * Changed syntax on Line 11, 16, and 34 to allow for this particular GH Actions workflow to rely upon the local copy of the yml file (example: `kapsakcj/docker-builds/.github/workflows/deploy-pangolin3.1.20-slim.yml` instead of pulling from the StaPH-B/docker-builds repo)
    * This allows me (and other users!) to use and test the GH Actions workflows in the forked repo and not pull the GH Actions workflow from StaPH-B repo: 

#### 3. Fixes slight bug in pangolin dockerfile
The micromamba-based version of Pangolin 3.1.20 ran great locally as well as via GH Actions workflow for testing, but Terra & Cromwell do some funny things when running docker containers. For some reason (not exactly sure what happens), the conda environment is not activated by default so we get errors complaining about `pangolin` not being on the $PATH. I've hard coded the conda environment to be in the PATH variable at all times, similar to what we had done previously with the ubuntu-xenial/miniconda-based version: https://github.com/StaPH-B/docker-builds/blob/16f8b4778e44c7fcff519f05aa5165513dda43db/pangolin/3.1.20/Dockerfile#L57


#### Adjusting pangolin dockerfile:
<!-- If this PR is to adjust an existing dockerfile  -->
- [x] Build your own docker image using a Dockerfile
  - [x] Includes the recommended LABELS
- [x] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
- [x] Ensure tool is listed in Program_Licenses.md
- [x] Ensure a simple container-specific README.md exists in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
- [x] Update GitHub actions workflow if needed
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository

#### Adjusting GH actions workflows:
<!-- If this PR is to adjust an existing GitHub actions workflow or to create one -->
- [x] Update relevant GitHub actions workflow files
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository