### PR TITLE
Update deploy workflows, make quay default but optional

### DIFF
--- a/.github/workflow-templates/deploy-template.yml
+++ b/.github/workflow-templates/deploy-template.yml
@@ -26,6 +26,8 @@ jobs:
     secrets: # these are the secret login credientials for pushing the containers to the repository
       docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      quay_username: ${{ secrets.quay_username }}
+      quay_robot_token: ${{ secrets.quay_robot_token }}
     with:
       path_to_context: "./<program name>/<program version>"  # Same as above
       dockerfile_name: "Dockerfile"  # Same as above

--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -10,9 +10,9 @@ on:
       docker_access_token:
         required: true
       quay_username:
-        required: true
+        required: false
       quay_robot_token:
-        required: true
+        required: false
     inputs:
       path_to_context:
         required: true
@@ -35,6 +35,10 @@ on:
         required: false
         default: latest
         type: string
+      push_quay:
+        default: true
+        required: false
+        type: boolean
 
 jobs:
 
@@ -46,6 +50,7 @@ jobs:
         with:
           lfs: true
 
+      # Git LFS not used by StaPH-B but maybe useful in some people's forks
       - name: Checkout LFS objects
         run: git lfs checkout
 
@@ -69,12 +74,13 @@ jobs:
 
       - name: Login to Quay
         uses: docker/login-action@v1
+        if: ${{ inputs.push_quay }}
         with:
           registry: quay.io
           username: ${{ secrets.quay_username }}
           password: ${{ secrets.quay_robot_token }}
 
-      - name: Build and push
+      - name: Build and push to DockerHub
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -84,9 +90,22 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache-${{ inputs.cache }}
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ inputs.cache }}-new # mode=max means export layers from all stage to cache
-          tags: | # pushing to both dockerhub and quay for both latest and user-defined inputs.tag
+          tags: | # pushing to dockerhub for both latest and user-defined inputs.tag
             ${{ inputs.repository_name }}/${{ inputs.container_name }}:latest
             ${{ inputs.repository_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
+
+      - name: Build and push to Quay
+        id: quay_build
+        uses: docker/build-push-action@v2
+        if: ${{ inputs.push_quay }}
+        with:
+          context: ${{ inputs.path_to_context }}
+          file: ${{ inputs.path_to_context }}/${{ inputs.dockerfile_name }}
+          target: app
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ inputs.cache }}
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ inputs.cache }}-new # mode=max means export layers from all stage to cache
+          tags: | # pushing to quay for both latest and user-defined inputs.tag
             quay.io/${{ inputs.repository_name }}/${{ inputs.container_name }}:latest
             quay.io/${{ inputs.repository_name }}/${{ inputs.container_name }}:${{ inputs.tag }}
 

--- a/.github/workflows/deploy-parsnp.yml
+++ b/.github/workflows/deploy-parsnp.yml
@@ -20,6 +20,8 @@ jobs:
     secrets:
       docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      quay_username: ${{ secrets.quay_username }}
+      quay_robot_token: ${{ secrets.quay_robot_token }}
     with:
       path_to_context: "./parsnp/1.5.6"
       dockerfile_name: "Dockerfile"


### PR DESCRIPTION
<!-- If this PR is to adjust an existing GitHub actions workflow or to create one -->
- [x] Update relevant GitHub actions workflow files
* Updated the deploy-template.yml to include quay login secrets
* Modified build-to-deploy.yml to make deploy to quay default but optional; this helps people like me who want to deploy from our forked repositories to a personal docker hub, but don't have a quay account
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
* NA
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository
* I re-based my add-dsk branch onto this branch and successfully deployed DSK to my docker hub, so the toggle quay on/off function is working (see how the quay steps were skipped [here](https://github.com/SarahNadeau/docker-builds/runs/5660615060?check_suite_focus=true)).


