### PR TITLE
Add tests for Trimmomatic 0.39

### DIFF
--- a/.github/workflow-templates/test-template.yml
+++ b/.github/workflow-templates/test-template.yml
@@ -16,7 +16,7 @@ jobs:
 
   # This job calls a workflow to build the image to the 'test' stage
   build-to-test:
-    uses: StaPH-B/docker-builds/.github/workflows/build-to-test.yml@master
+    uses: ./.github/workflows/build-to-test.yml
     with:
       path_to_context: "./<program name>/<program version>"  # Path to directory with Dockerfile and context, e.g. "./spades/3.12.0"
       dockerfile_name: "Dockerfile"

--- a/.github/workflows/deploy-trimmomatic.yml
+++ b/.github/workflows/deploy-trimmomatic.yml
@@ -1,0 +1,34 @@
+
+name: Deploy Trimmomatic image
+
+on: workflow_dispatch
+
+jobs:
+
+  build-to-test:
+    uses: StaPH-B/docker-builds/.github/workflows/build-to-test.yml@master
+    with:
+      path_to_context: "./trimmomatic/0.39"
+      dockerfile_name: "Dockerfile"
+      cache: "trimmomatic"
+
+  build-to-deploy:
+    needs: build-to-test
+    uses: StaPH-B/docker-builds/.github/workflows/build-to-deploy.yml@master
+    secrets:
+      docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      quay_username: ${{ secrets.quay_username }}
+      quay_robot_token: ${{ secrets.quay_robot_token }}
+    with:
+      path_to_context: "./trimmomatic/0.39"
+      dockerfile_name: "Dockerfile"
+      cache: "trimmomatic"
+      container_name: "trimmomatic"
+      tag: "0.39"
+
+  run-singularity:
+    needs: build-to-deploy
+    uses: StaPH-B/docker-builds/.github/workflows/run-singularity.yml@master
+    with:
+      image_name: "trimmomatic:0.39"

--- a/.github/workflows/test-trimmomatic.yml
+++ b/.github/workflows/test-trimmomatic.yml
@@ -1,0 +1,17 @@
+
+name: Test Trimmomatic image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "trimmomatic/0.39/Dockerfile"
+
+jobs:
+
+  build-to-test:
+    uses: ./.github/workflows/build-to-test.yml
+    with:
+      path_to_context: "./trimmomatic/0.39"
+      dockerfile_name: "Dockerfile"
+      cache: "trimmomatic"

--- a/trimmomatic/0.39/Dockerfile
+++ b/trimmomatic/0.39/Dockerfile
@@ -1,5 +1,5 @@
 #use ubuntu as base image
-FROM ubuntu:xenial
+FROM ubuntu:xenial as app
 
 # metadata
 LABEL base.image="ubuntu:xenial"
@@ -36,3 +36,16 @@ ENV PATH="${PATH}:/Trimmomatic-0.39/"
 # create /data directory and set as working directory
 RUN mkdir /data
 WORKDIR /data
+
+FROM app as test
+
+# Get test dependencies
+RUN apt-get update && apt-get install -y python3
+COPY tests /tests/
+
+# Run program on test data
+RUN bash /tests/scripts/get_data_pos_control.sh
+RUN bash /tests/scripts/run_trimmomatic_pos_control.sh
+
+# Verify output
+RUN python3 -m unittest discover -s /tests

--- a/trimmomatic/0.39/README.md
+++ b/trimmomatic/0.39/README.md
@@ -1,0 +1,51 @@
+# Trimmomatic
+
+This image implements the read-trimming software [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic).
+Documentation is available at http://www.usadellab.org/cms/?page=trimmomatic. 
+
+## Example usage
+This example useage is taken from the built-in tests for this image. See [run_trimmomatic_pos_control.sh](tests/scripts/run_trimmomatic_pos_control.sh).
+
+```bash
+# Input data are paired-end reads
+R1=/data/R1.fastq.gz
+R2=/data/R2.fastq.gz
+
+# Set up an output directory
+OUTDIR=/test_result
+mkdir -p $OUTDIR
+
+# Use adaptor file that comes with the software
+ADAPTERS="/Trimmomatic-0.39/adapters/TruSeq3-PE.fa"  # trimmomatic docs says these are used in HiSeq and MiSeq machines
+
+# Run trimmomatic to trim & filter reads
+trimmomatic \
+  PE \
+  -phred33 \
+  $R1 $R2 \
+  $OUTDIR/R1.paired.fq $OUTDIR/R1.unpaired.fq \
+  $OUTDIR/R2.paired.fq $OUTDIR/R2.unpaired.fq \
+  ILLUMINACLIP:$ADAPTERS:2:20:10:8:TRUE \
+  SLIDINGWINDOW:6:30 LEADING:10 TRAILING:10 MINLEN:50
+```
+
+## Example output 
+
+The on-screen output tells you what trimmomatic did and how many reads got filtered out:
+```
+TrimmomaticPE: Started with arguments:
+-phred33 /data/R1.fastq.gz /data/R2.fastq.gz /test_result/R1.paired.fq /test_result/R1.unpaired.fq /test_result/R2.paired.fq /test_result/R2.unpaired.fq ILLUMINACLIP:/Trimmomatic-0.39/adapters/TruSeq3-PE.fa:2:20:10:8:TRUE SLIDINGWINDOW:6:30 LEADING:10 TRAILING:10 MINLEN:50
+Multiple cores found: Using 2 threads
+Using PrefixPair: 'TACACTCTTTCCCTACACGACGCTCTTCCGATCT' and 'GTGACTGGAGTTCAGACGTGTGCTCTTCCGATCT'
+ILLUMINACLIP: Using 1 prefix pairs, 0 forward/reverse sequences, 0 forward only sequences, 0 reverse only sequences
+Input Read Pairs: 830228 Both Surviving: 526702 (63.44%) Forward Only Surviving: 109472 (13.19%) Reverse Only Surviving: 48718 (5.87%) Dropped: 145336 (17.51%)
+TrimmomaticPE: Completed successfully
+```
+
+The result files from this command are:
+```
+R1.paired.fq
+R1.unpaired.fq
+R2.paired.fq
+R2.unpaired.fq
+```

--- a/trimmomatic/0.39/tests/scripts/get_data_pos_control.sh
+++ b/trimmomatic/0.39/tests/scripts/get_data_pos_control.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This script downloads read files from NCBI for SRR5481494 (https://www.ncbi.nlm.nih.gov/sra/SRR5481494).
+
+DATADIR=/data
+mkdir -p $DATADIR
+
+# Download raw reads from ENA FTP site
+wget -nv ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR548/004/SRR5481494/SRR5481494_1.fastq.gz -O $DATADIR/R1.fastq.gz
+wget -nv ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR548/004/SRR5481494/SRR5481494_2.fastq.gz -O $DATADIR/R2.fastq.gz

--- a/trimmomatic/0.39/tests/scripts/run_trimmomatic_pos_control.sh
+++ b/trimmomatic/0.39/tests/scripts/run_trimmomatic_pos_control.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This script runs trimmomatic to remove Illumina sequencing adaptors and quality-trim/quality-filter reads.
+
+R1=/data/R1.fastq.gz
+R2=/data/R2.fastq.gz
+OUTDIR=/test_result
+mkdir -p $OUTDIR
+
+ADAPTERS="/Trimmomatic-0.39/adapters/TruSeq3-PE.fa"  # trimmomatic docs says these are used in HiSeq and MiSeq machines
+
+echo "Running trimmomatic on test data to trim & filter reads"
+trimmomatic \
+  PE \
+  -phred33 \
+  $R1 $R2 \
+  $OUTDIR/R1.paired.fq $OUTDIR/R1.unpaired.fq \
+  $OUTDIR/R2.paired.fq $OUTDIR/R2.unpaired.fq \
+  ILLUMINACLIP:$ADAPTERS:2:20:10:8:TRUE \
+  SLIDINGWINDOW:6:30 LEADING:10 TRAILING:10 MINLEN:50
+
+for R in R1 R2; do
+  for P in paired unpaired; do
+    # Thanks: https://edwards.flinders.edu.au/sorting-fastq-files-by-their-sequence-identifiers/
+    cat $OUTDIR/$R.$P.fq | paste - - - - | sort -k1,1 -t " " | tr "\t" "\n" | sha256sum > $OUTDIR/$R.$P.fq.sha256sum
+  done
+done

--- a/trimmomatic/0.39/tests/test_controls.py
+++ b/trimmomatic/0.39/tests/test_controls.py
@@ -1,0 +1,28 @@
+import unittest
+
+
+class TestPositiveControl(unittest.TestCase):
+
+    def test_output_trimmed_r1_paired(self):
+        with open("/test_result/R1.paired.fq.sha256sum", 'r') as f:
+            checksum = f.readlines()[0].split(" ")[0]
+        self.assertEqual(checksum, "a401ef04fb1d0dc8903aada4831fc3544212d7373f53ef000faaa5a1640cbe5e")
+
+    def test_output_trimmed_r1_unpaired(self):
+        with open("/test_result/R1.unpaired.fq.sha256sum", 'r') as f:
+            checksum = f.readlines()[0].split(" ")[0]
+        self.assertEqual(checksum, "7ad99ed6b8b9b03ef8de3a5152f5e0083ec21fce9c56c1c3171ec26328c860eb")
+
+    def test_output_trimmed_r2_paired(self):
+        with open("/test_result/R2.paired.fq.sha256sum", 'r') as f:
+            checksum = f.readlines()[0].split(" ")[0]
+        self.assertEqual(checksum, "3511ee4e96180b0c62b1dfb3f403967268703908b165945dec84022b0a971e27")
+
+    def test_output_trimmed_r2_unpaired(self):
+        with open("/test_result/R2.unpaired.fq.sha256sum", 'r') as f:
+            checksum = f.readlines()[0].split(" ")[0]
+        self.assertEqual(checksum, "6971c6b2f948a1d3c8dced7f6ec32b2d4fbebde374ce2f76e8ad5f02b94ff2be")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trimmomatic/0.39/tests/test_versions.py
+++ b/trimmomatic/0.39/tests/test_versions.py
@@ -1,0 +1,15 @@
+import unittest
+import subprocess
+from subprocess import PIPE
+
+
+class TestVersions(unittest.TestCase):
+
+    def test_version_trimmomatic(self):
+        bash_cmd = "trimmomatic -version"
+        result = subprocess.run(bash_cmd, shell=True, stdout=PIPE)
+        self.assertEqual(b"0.39\n", result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request adds built-in tests for trimmomatic/0.39. 
It also fixes the path to the build-to-test.yml workflow to be local so that this workflow runs upon pull request. See https://github.com/StaPH-B/docker-builds/pull/320#discussion_r835425527. 

<!-- If this PR is to adjust an existing dockerfile  -->
- [x] Build your own docker image using a Dockerfile
  - [x] Includes the recommended LABELS
- [x] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
- [x] Ensure tool is listed in Program_Licenses.md
- [x] Ensure a simple container-specific README.md exists in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
- [x] Update GitHub actions workflow if needed
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository
See https://github.com/SarahNadeau/docker-builds/actions/runs/2070906094. 