### PR TITLE
total revamp of Freyja 1.3.4 dockerfile. Now using micromamba as a ba…

### DIFF
--- a/freyja/1.3.4/Dockerfile
+++ b/freyja/1.3.4/Dockerfile
@@ -1,23 +1,41 @@
-FROM continuumio/miniconda:4.7.12 as app
+FROM mambaorg/micromamba:0.22.0 as app
 
 # Version arguments
+# ARG variables only persist during build time
 ARG FREYJA_SOFTWARE_VERSION="1.3.4"
 
-LABEL base.image="continuumio/miniconda:4.7.12"
-LABEL dockerfile.version="1"
+# build and run as root users since micromamba image has 'mambauser' set as the $USER
+USER root
+# set workdir to default for building; set to /data at the end
+WORKDIR /
+
+LABEL base.image="mambaorg/micromamba:0.22.0"
+LABEL dockerfile.version="2"
 LABEL software="Freyja"
 LABEL software.version=${FREYJA_SOFTWARE_VERSION}
 LABEL description="Freyja is a tool to recover relative lineage abundances from mixed SARS-CoV-2 samples from a sequencing dataset (BAM aligned to the Hu-1 reference)"
 LABEL website="https://github.com/andersen-lab/Freyja"
 LABEL license="https://github.com/andersen-lab/Freyja/blob/main/LICENSE"
-LABEL maintainer="Kevin Libuit"
-LABEL maintainer.email="kevin.libuit@theiagen.com"
+LABEL maintainer1="Kevin Libuit"
+LABEL maintainer1.email="kevin.libuit@theiagen.com"
+LABEL maintainer2="Kevin Libuit"
+LABEL maintainer2.email="curtis.kapsak@theiagen.com"
 
-# Create Freyja conda environment and add to PATH
-RUN conda create -n freyja-env -c conda-forge -c bioconda -c defaults freyja=${FREYJA_SOFTWARE_VERSION} \
-&& echo "source activate freyja-env" > ~/.bashrc
+# install dependencies; cleanup apt garbage
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ wget \
+ ca-certificates \
+ procps && \
+ apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH /opt/conda/envs/freyja-env/bin:/opt/conda/envs/env/bin:$PATH
+# Create Freyja conda environment called freyja-env from bioconda recipe
+# clean up conda garbage
+RUN micromamba create -n freyja-env -c conda-forge -c bioconda -c defaults freyja=${FREYJA_SOFTWARE_VERSION} && \
+ micromamba clean -a -y
+
+# set the environment, put new conda env in PATH by default
+ENV PATH="/opt/conda/envs/freyja-env/bin:/opt/conda/envs/env/bin:${PATH}" \
+ LC_ALL=C.UTF-8
 
 # set working directory to /data
 WORKDIR /data
@@ -28,11 +46,13 @@ FROM app as test
 # Grab test data
 COPY tests/ /data/
 
+# so that mamba/conda env is active when running below commands
+ENV ENV_NAME="freyja-env"
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
 # Run Freyja
 RUN freyja variants /data/Freyja_WWSC2.bam --variants /data/test_variants.tsv --depths /data/test_depths.tsv --ref /data/nCoV-2019.reference.fasta && freyja demix /data/test_variants.tsv /data/test_depths.tsv --output /data/test_demix.tsv
 
 # Check validity of outputs
 RUN cmp /data/test_variants.tsv /data/Freyja_variants.tsv && cmp /data/test_depths.tsv /data/Freyja_depths.tsv
 RUN grep "Omicron" /data/test_demix.tsv && echo done
-
-


### PR DESCRIPTION
…se. `ps` is included for nextflow compatibility. Should address #335 as far as nextflow compatibility goes. Not completely sure about the issue @kevinlibuit described.

- [x] This comment contains a description of what is in the pull request.

This PR changes the existing Freyja 1.3.4 Dockerfile. `LABEL dockerfile.version=2` bumped to 2 since I'm updating the existing dockerfile.

This cuts the size of the docker image by almost half 🎉 
```
$ docker images | grep freyja
kapsakcj/freyja   1.3.4-micromamba   3eb722a9bad2   About a minute ago   1.4GB
staphb/freyja     1.3.4              0d7bbf9eac9a   8 days ago           2.5GB
```
It also greatly reduces the time to build the image. `micromamba` sure is fast.


 GH actions workflows should not need adjusting 👍 

Docker image built fine locally, including the test layer. We should see the same output/result with the GH actions test workflow

<!-- If this PR is to adjust an existing dockerfile  -->
- [x] Build your own docker image using a Dockerfile
  - [x] Includes the recommended LABELS
- [x] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
- [x] Ensure tool is listed in Program_Licenses.md
- [x] Ensure a simple container-specific README.md exists in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
- [x] Update GitHub actions workflow if needed
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository
