### PR TITLE
update pangolin 4.0.6 with pangolin-data 1.8 

### DIFF
--- a/pangolin/4.0.6/Dockerfile
+++ b/pangolin/4.0.6/Dockerfile
@@ -9,14 +9,14 @@ WORKDIR /
 # had to include the v for some of these due to GitHub tags.
 # using pangolin-data github tag, NOT what is in the GH release title "v1.2.133"
 ARG PANGOLIN_VER="v4.0.6"
-ARG PANGOLIN_DATA_VER="v1.6"
+ARG PANGOLIN_DATA_VER="v1.8"
 ARG SCORPIO_VER="v0.3.17"
 ARG CONSTELLATIONS_VER="v0.1.8"
 ARG USHER_VER="0.5.3"
 
 # metadata labels
 LABEL base.image="mambaorg/micromamba:0.22.0"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="pangolin"
 LABEL software.version=${PANGOLIN_VER}
 LABEL description="Conda environment for Pangolin. Pangolin: Software package for assigning SARS-CoV-2 genome sequences to global lineages."

--- a/pangolin/4.0.6/Dockerfile
+++ b/pangolin/4.0.6/Dockerfile
@@ -12,7 +12,7 @@ ARG PANGOLIN_VER="v4.0.6"
 ARG PANGOLIN_DATA_VER="v1.8"
 ARG SCORPIO_VER="v0.3.17"
 ARG CONSTELLATIONS_VER="v0.1.8"
-ARG USHER_VER="0.5.3"
+ARG USHER_VER="0.5.4"
 
 # metadata labels
 LABEL base.image="mambaorg/micromamba:0.22.0"


### PR DESCRIPTION
Would like to upgrade usher to 0.5.4, but it's not yet available via bioconda (may change soon?)

The same GH actions workflows can be re-used

- [x] This comment contains a description of what is in the pull request.
This PR updates the pangolin 4.0.6 dockerfile with pangolin-data 1.8. bumps `dockerfile.version` to 2.

<!-- If this PR is to adjust an existing dockerfile  -->
- [x] Build your own docker image using a Dockerfile
  - [x] Includes the recommended LABELS
- [x] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
- [x] Ensure tool is listed in Program_Licenses.md
- [x] Ensure a simple container-specific README.md exists in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
- [x] Update GitHub actions workflow if needed
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository

