### PR TITLE
update kraken2 v2.1.2 dockerfile

### DIFF
--- a/.github/workflows/deploy-kraken-2.1.2.yml
+++ b/.github/workflows/deploy-kraken-2.1.2.yml
@@ -1,0 +1,43 @@
+# This caller workflow tests, builds, and pushes the image to Docker Hub.
+# It also tests that a Singularity container can be run from the Docker image.
+# Instructions: replace all the <placeholder> stubs in this template with values for your image.
+# Some explanations come from: https://github.com/actions/starter-workflows/blob/main/automation/manual.yml
+
+name: Deploy Kraken2 v2.1.2 image
+
+# This workflow should run when manually triggered by StaPH-B repo maintainer
+on: workflow_dispatch
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  # This job calls a workflow to build the image to the 'test' stage
+  build-to-test:
+    uses: StaPH-B/docker-builds/.github/workflows/build-to-test.yml@master
+    with:
+      path_to_context: "./kraken2/2.1.2"  # Path to directory with Dockerfile and context, e.g. "./spades/3.12.0"; if you need to have the whole repo as context (e.g. to use files in test_data), use "."
+      dockerfile_name: "Dockerfile"  # Name of the Dockerfile, should be "Dockerfile"; if you need to have the whole repo as context, use e.g. "./spades/3.12.0/Dockerfile"
+      cache: "kraken2"  # Use the program name as a nickname for a GitHub cache of your image's layers, e.g. "spades". The cache will speed up re-running the workflow.
+
+  # This job calls a workflow to build the image to the 'app' stage and pushes the image to Docker Hub
+  build-to-deploy:
+    needs: build-to-test  # this jobs needs to run serially, after testing succeeds
+    uses: StaPH-B/docker-builds/.github/workflows/build-to-deploy.yml@master
+    secrets: # these are the secret login credientials for pushing the containers to the repository
+      docker_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      docker_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      quay_username: ${{ secrets.quay_username }}
+      quay_robot_token: ${{ secrets.quay_robot_token }}
+    with:
+      path_to_context: "./kraken2/2.1.2"  # Same as above
+      dockerfile_name: "Dockerfile"  # Same as above
+      cache: "kraken2"  # Same as above
+      container_name: "kraken2"  # The image name for Docker Hub, use the program name in lowercase, e.g. "spades"
+      tag: "2.1.2-no-db"  # The image tag for Docker Hub, use the program version, e.g. "3.12.0"
+
+  # This job calls a workflow to pull the image from Docker Hub and test that it can be run as a Singularity container
+  run-singularity:
+    needs: build-to-deploy  # test singularity run on newly pushed Docker image
+    uses: StaPH-B/docker-builds/.github/workflows/run-singularity.yml@master
+    with:
+      image_name: "kraken2:2.1.2-no-db"  # The image to pull, e.g. "spades:3.12.0"

--- a/.github/workflows/test-kraken2-2.1.2.yml
+++ b/.github/workflows/test-kraken2-2.1.2.yml
@@ -1,0 +1,23 @@
+# This caller workflow builds an image to the "test" stage.
+# Instructions: replace all the <placeholder> stubs in this template with values for your image.
+# Some explanations come from: https://github.com/actions/starter-workflows/blob/main/automation/manual.yml
+
+name: Test Kraken2 image
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI or when you submit your pull request
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "kraken2/2.1.2/Dockerfile"  # Dockerfile path, e.g. 'htslib/1.14/Dockerfile' so that only your image is tested
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  # This job calls a workflow to build the image to the 'test' stage
+  build-to-test:
+    uses: ./.github/workflows/build-to-test.yml
+    with:
+      path_to_context: "./kraken2/2.1.2"  # Path to directory with Dockerfile and context, e.g. "./spades/3.12.0"
+      dockerfile_name: "Dockerfile"
+      cache: "kraken2"  # Use the program name as a nickname for a GitHub cache of your image's layers, e.g. "spades". The cache will speed up re-running the workflow.

--- a/kraken2/2.1.2/Dockerfile
+++ b/kraken2/2.1.2/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal as app
 
 # for easy upgrade later. ARG variables only persist during build time.
 ARG K2VER="2.1.2"
 
-LABEL base.image="ubuntu:xenial"
-LABEL dockerfile.version="1"
+LABEL base.image="ubuntu:focal"
+LABEL dockerfile.version="2"
 LABEL software="Kraken2"
 LABEL software.version="2.1.2"
 LABEL description="Taxonomic sequence classifier"
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
  make \
  g++ \
  rsync \
- cpanminus && \
+ cpanminus \
+ ncbi-blast+ && \
  rm -rf /var/lib/apt/lists/* && apt-get autoclean
 
 # perl module required for kraken2-build
@@ -39,6 +40,15 @@ ENV PATH="$PATH:/kraken2-${K2VER}" \
     LC_ALL=C
 
 WORKDIR /data
+
+FROM app as test 
+
+RUN kraken2 --help && \
+ kraken2-build --help && \
+ kraken2 --version && \
+ blastn -version && \
+ dustmasker -version && \
+ segmasker -version
 
 ##### NO DATABASE INCLUDED WITH THIS DOCKER IMAGE #####
 ## User will need to mount a directory from their host machine that contains kraken2 database files 

--- a/kraken2/2.1.2/README.md
+++ b/kraken2/2.1.2/README.md
@@ -1,0 +1,25 @@
+# <program> container
+
+Main tool : [Kraken2](https://github.com/DerrickWood/kraken2/)
+
+Additional tools:
+- [Pre-built kraken2 databases can be found here](https://benlangmead.github.io/aws-indexes/k2)
+
+Full documentation: [link to documentation](https://github.com/DerrickWood/kraken2/wiki)
+
+Kraken 2 is a fast and memory efficient tool for taxonomic assignment of metagenomics sequencing reads.
+
+# Example Usage
+
+```bash
+# query Illumina paired-end reads against kraken2 standard 8GB database
+kraken2 --report test.kraken2.1.2.salmonella.report \
+  --output test.kraken2.1.2.salmonella.output \
+  --paired \
+  --db ./k2_standard_8gb_20210517 \
+  --threads 4 \
+  SRR10992628_1.gz SRR10992628_2.gz 
+
+# inspect a kraken2 database
+kraken2-inspect --db ./k2_standard_8gb_20210517 --threads 4
+```


### PR DESCRIPTION
- [x] This comment contains a description of what is in the pull request.
- upgrade to `ubuntu:focal` base from `ubuntu:xenial`
- adds app & test layers
  - testing is minimal; only printing of versions and help options - I don't want to download a DB and sequences in a test layer as it will be too much of a hassle with the size of even the smallest db's
- adds ncbi-blast+ suite since `dustmasker` and `segmasker` are optional (but default) for `kraken2-build`
- adds GH actions workflows for testing and deployment
- `dockerfile.version=2`
  - planning to overwrite the previous docker image tag `staphb/kraken2:2.1.2-no-db` 


<!-- If this PR is to adjust an existing dockerfile  -->
- [x] Build your own docker image using a Dockerfile
  - [x] Includes the recommended LABELS
- [x] (Optional) Dockerfile is built with best practices and has been approved by a linter (such as https://hadolint.github.io/hadolint/)
- [x] Ensure tool is listed in Program_Licenses.md
- [x] Ensure a simple container-specific README.md exists in the same directory as the Dockerfile (i.e. spades/3.12.0/README.md)
- [x] Update GitHub actions workflow if needed
- [x] Any files required for building are located in the same directory as the Dockerfile (i.e. spades/3.12.0/my_spades_tests.sh)
- [x] Have successfully run the workflow "Test <program name> image" in your forked repository

