### PR TITLE
fix panaroo conda env

### DIFF
--- a/panaroo/1.2.10/Dockerfile
+++ b/panaroo/1.2.10/Dockerfile
@@ -54,5 +54,5 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 # Run Panaroo
 RUN mkdir /data/panaroo_results && panaroo -i /data/*.gff -o /data/panaroo_results/ --clean-mode strict
 # Check validity of outputs
-RUN cmp /data/gene_data.csv /data/panaroo_results/gene_data.csv
-RUN cmp /data/summary_statistics.txt /data/panaroo_results/summary_statistics.txt
+RUN cmp /data/gene_data.csv /data/panaroo_results/gene_data.csv && \
+ cmp /data/summary_statistics.txt /data/panaroo_results/summary_statistics.txt

--- a/panaroo/1.2.10/panaroo-environment.yml
+++ b/panaroo/1.2.10/panaroo-environment.yml
@@ -243,7 +243,7 @@ dependencies:
 - perl-carp=1.50=pl5321hd8ed1ab_0
 - perl-test-differences=0.69=pl5321hdfd78af_0
 - perl-test-deep=1.130=pl5321hdfd78af_0
-- openssl=3.0.4=h166bdaf_0
+- openssl=3.0.4
 - plotly=5.9.0=pyhd8ed1ab_0
 - perl-xml-regexp=0.04=pl5321hdfd78af_3
 - python=3.9.13=h2660328_0_cpython


### PR DESCRIPTION
unpins openssl build version in panaroo conda env. pinned version was labeled "broken" according to this: https://anaconda.org/conda-forge/openssl/files

This small change allows the conda/micromamba environment to solve and build successfully.

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
