### PR TITLE
improvements to plasmidfinder 2.1.6 dockerfile

### DIFF
--- a/plasmidfinder/2.1.6/Dockerfile
+++ b/plasmidfinder/2.1.6/Dockerfile
@@ -11,20 +11,21 @@ ARG KMA_VER="1.0.1"
 # LABEL instructions tag the image with metadata that might be important to the user
 # Optional, but highly recommended
 LABEL base.image="debian:stretch"
-LABEL dockerfile.version="2"
+LABEL dockerfile.version="3"
 LABEL software="plasmidfinder"
-LABEL software.version=$PLASMIDFINDER_VER
+LABEL software.version="${PLASMIDFINDER_VER}"
 LABEL description="Identifies plasmids in total or partial sequenced isolates of bacteria."
 LABEL website="https://bitbucket.org/genomicepidemiology/plasmidfinder/src/master/"
 LABEL license="https://bitbucket.org/genomicepidemiology/plasmidfinder/src/master/README.md"
 LABEL maintainer="John Arnn"
 LABEL maintainer.email="jarnn@utah.gov"
 
-
-ENV DEBIAN_FRONTEND noninteractive
+# ARG so that this variable only persists at image build time
+ARG DEBIAN_FRONTEND noninteractive
 
 # RUN executes code during the build
 # Install dependencies via apt-get or yum if using a centos or fedora base
+# ncbi-blast v2.6.0 via debian:stretch apt
 RUN apt-get update -y && apt-get install -y \
     apt-utils \
     wget \
@@ -44,28 +45,32 @@ RUN pip3 install --upgrade pip && \
 RUN wget https://bitbucket.org/genomicepidemiology/kma/get/${KMA_VER}.tar.gz && \
     mkdir kma && \
     tar -xvf ${KMA_VER}.tar.gz -C kma --strip-components 1 && \
+    rm ${KMA_VER}.tar.gz && \
     cd kma && make && \
     mv kma* /bin/
 
 RUN wget https://bitbucket.org/genomicepidemiology/plasmidfinder/get/${PLASMIDFINDER_VER}.tar.gz && \
-    mkdir plasmidfinder && tar -xvf ${PLASMIDFINDER_VER}.tar.gz -C plasmidfinder --strip-components 1
+    mkdir plasmidfinder && \
+    tar -xvf ${PLASMIDFINDER_VER}.tar.gz -C plasmidfinder --strip-components 1 && \
+    rm ${PLASMIDFINDER_VER}.tar.gz
 
 ENV PATH="${PATH}:/plasmidfinder"
 
 RUN chmod 755 plasmidfinder/plasmidfinder.py 
 
 RUN wget https://bitbucket.org/genomicepidemiology/plasmidfinder_db/get/${PLASMIDFINDER_DB_VER}.tar.gz && \
-    mkdir plasmidfinder_db && tar -xvf ${PLASMIDFINDER_DB_VER}.tar.gz -C plasmidfinder_db --strip-components 1 && \
+    mkdir plasmidfinder_db && \
+    tar -xvf ${PLASMIDFINDER_DB_VER}.tar.gz -C plasmidfinder_db --strip-components 1 && \
+    rm ${PLASMIDFINDER_DB_VER}.tar.gz && \
     cd plasmidfinder_db && \
     python3 INSTALL.py kma_index && \
     cd .. && \
     mv plasmidfinder_db database
 
-
 WORKDIR /data
 
 FROM app as test
 
-RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR193/000/ERR1937840/ERR1937840.fastq.gz
-RUN gzip -d ERR1937840.fastq.gz && mkdir test && \
+RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR193/000/ERR1937840/ERR1937840.fastq.gz && \
+    gzip -d ERR1937840.fastq.gz && mkdir test && \
     plasmidfinder.py -i ERR1937840.fastq -o test


### PR DESCRIPTION
CC @jwarnn 

* Main reason for this PR is to change `ENV DEBIAN_FRONTEND noninteractive` to `ARG DEBIAN_FRONTEND noninteractive` so the variable does not persist in the environment after the docker image is built. I've hit a few issues with the container due to this env variable
* bumped `dockerfile.version` to `3`
* added lines for deleting a few .tar.gz files after unpacking
* consolidated test layer to use one less `RUN` layer

Planning to overwrite the existing docker image tags `staphb/plasmidfinder:latest` and `staphb/plasmidfinder:2.1.6` on dockerhub and quay

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing
