### PR TITLE
added `zip` and `unzip` to vadr 1.4.2

### DIFF
--- a/vadr/1.4.2/Dockerfile
+++ b/vadr/1.4.2/Dockerfile
@@ -23,7 +23,7 @@ ENV PERL5LIB=$VADRSCRIPTSDIR:$VADRSEQUIPDIR:$VADRBIOEASELDIR/blib/lib:$VADRBIOEA
 
 # metadata - optional, but highly recommended
 LABEL base.image="ubuntu:xenial"
-LABEL dockerfile.version="2"
+LABEL dockerfile.version="3"
 LABEL software="VADR"
 LABEL software.version=${VADR_VERSION}
 LABEL description="Classification and annotation of viral sequences based on RefSeq annotation"
@@ -43,7 +43,9 @@ RUN apt-get update && apt-get install -y \
  build-essential \
  autoconf \
  libinline-c-perl \
- liblwp-protocol-https-perl && \
+ liblwp-protocol-https-perl \
+ zip \
+ unzip && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
 # install VADR


### PR DESCRIPTION
Also - `dockerfile.version` bumped to `3`

I'd like to be able to `zip` up the numerous output files from VADR and `.zip` is probably the best format that is most easily uncompressed/extracted on Windows machines (without having to install 7-zip or similar 3rd party software)

The docker image obviously has `tar` and gzip-compression available, but `.tar.gz` archives are not easy to extract when on a Windows machine. (You usually have to download 3rd party decompression/extraction software to accomplish this)

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
