### PR TITLE
seqsero2 1.2.1 fix

### DIFF
--- a/seqsero2/1.2.1/Dockerfile
+++ b/seqsero2/1.2.1/Dockerfile
@@ -1,11 +1,14 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic as app
 
 # for easy upgrade later. ARG variables only persist during build time
 ARG SEQSERO2_VER="1.2.1"
+ARG SPADES_VER="3.15.5"
+ARG SAMTOOLS_VER="1.9"
+ARG SALMID_VER="0.122"
 
 # Metadata
 LABEL base.image="ubuntu:bionic"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="SeqSero2"
 LABEL software.version="1.2.1"
 LABEL description="Salmonella serotyping from genome sequencing data"
@@ -14,7 +17,7 @@ LABEL license="https://github.com/denglab/SeqSero2/blob/master/LICENSE"
 LABEL maintainer1="Jake Garfin"
 LABEL maintainer1.email="jake.garfin@state.mn.us"
 LABEL maintainer2="Curtis Kapsak"
-LABEL maintainer2.email="pjx8@cdc.gov"
+LABEL maintainer2.email="kapsakcj@gmail.com"
 LABEL maintainer3="Kelsey Florek"
 LABEL maintainer3.email="kelsey.florek@slh.wisc.edu"
 
@@ -25,14 +28,17 @@ LABEL maintainer3.email="kelsey.florek@slh.wisc.edu"
 # sra-toolkit = 2.8.2
 # bwa = 0.7.17
 # ncbi-blast+ = 2.6.0
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
  python3 \
  python3-pip \
+ python3-setuptools \
  bwa \
  ncbi-blast+ \
  sra-toolkit \
  bedtools \
  wget \
+ ca-certificates \
+ unzip \
  zlib1g-dev \
  libbz2-dev \
  liblzma-dev \
@@ -40,33 +46,78 @@ RUN apt-get update && apt-get install -y \
  libncurses5-dev && \
  rm -rf /var/lib/apt/lists/* && apt-get autoclean
 
-# Install samtools 1.9
-RUN wget 'https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2' && \
- tar -xvf samtools-1.9.tar.bz2 && \
- rm samtools-1.9.tar.bz2 && \
- cd samtools-1.9 && \
- make
+# Install samtools 
+RUN wget https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VER}/samtools-${SAMTOOLS_VER}.tar.bz2 && \
+ tar -xjf samtools-${SAMTOOLS_VER}.tar.bz2 && \
+ rm -v samtools-${SAMTOOLS_VER}.tar.bz2 && \
+ cd samtools-${SAMTOOLS_VER} && \
+ ./configure && \
+ make && \
+ make install
 
-# Install salmID 0.122
-RUN wget https://github.com/hcdenbakker/SalmID/archive/0.122.tar.gz && \
- tar -xzf 0.122.tar.gz && \
- rm -rf 0.122.tar.gz
+# Install salmID 
+RUN wget https://github.com/hcdenbakker/SalmID/archive/${SALMID_VER}.tar.gz && \
+ tar -xzf ${SALMID_VER}.tar.gz && \
+ rm -rvf ${SALMID_VER}.tar.gz
 
-# Install SPAdes 3.9.0
-RUN wget https://github.com/ablab/spades/releases/download/v3.9.0/SPAdes-3.9.0-Linux.tar.gz && \
- tar -xzf SPAdes-3.9.0-Linux.tar.gz && \
- rm -rf SPAdes-3.9.0-Linux.tar.gz
+# install SPAdes binary
+RUN wget http://cab.spbu.ru/files/release${SPADES_VER}/SPAdes-${SPADES_VER}-Linux.tar.gz && \
+  tar -xzf SPAdes-${SPADES_VER}-Linux.tar.gz && \
+  rm -rv SPAdes-${SPADES_VER}-Linux.tar.gz
 
 # Install SeqSero2; make /data
 RUN wget https://github.com/denglab/SeqSero2/archive/v${SEQSERO2_VER}.tar.gz && \
  tar -xzf v${SEQSERO2_VER}.tar.gz && \
- rm -rf v${SEQSERO2_VER}.tar.gz && \
+ rm -vrf v${SEQSERO2_VER}.tar.gz && \
  cd /SeqSero2-${SEQSERO2_VER}/ && \
  python3 -m pip install . && \
  mkdir /data
 
 # PATH edited to include /SeqSero2-1.1.0/bin in previous python3 command
-ENV PATH="${PATH}:/SPAdes-3.9.0-Linux/bin:/SalmID-0.122:/samtools-1.9" \
+ENV PATH="${PATH}:/SPAdes-${SPADES_VER}-Linux/bin:/SalmID-${SALMID_VER}:/samtools-${SAMTOOLS_VER}" \
     LC_ALL=C
 
 WORKDIR /data
+
+FROM app as test
+
+WORKDIR /test
+
+# install ncbi datasets tool (pre-compiled binary); place in $PATH
+RUN wget https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/LATEST/linux-amd64/datasets && \
+ chmod +x datasets && \
+ mv -v datasets /usr/local/bin
+
+# download an example assembly; test with SeqSero2
+# Salmonella enterica serovar Infantis genome: https://www.ncbi.nlm.nih.gov/data-hub/genome/GCA_007765495.1/
+# BioSample:SAMN07684583
+ARG GENBANK_ACCESSION="GCA_007765495.1"
+RUN datasets download genome accession ${GENBANK_ACCESSION} --filename ${GENBANK_ACCESSION}.zip && \
+    mkdir -v ${GENBANK_ACCESSION}-download && \
+    unzip ${GENBANK_ACCESSION}.zip -d ${GENBANK_ACCESSION}-download && \
+    rm ${GENBANK_ACCESSION}.zip && \
+    mv -v ${GENBANK_ACCESSION}-download/ncbi_dataset/data/${GENBANK_ACCESSION}/${GENBANK_ACCESSION}*.fna ${GENBANK_ACCESSION}-download/ncbi_dataset/data/${GENBANK_ACCESSION}/${GENBANK_ACCESSION}.genomic.fna && \
+    SeqSero2_package.py \
+      -i ${GENBANK_ACCESSION}-download/ncbi_dataset/data/${GENBANK_ACCESSION}/${GENBANK_ACCESSION}.genomic.fna \
+      -t 4 \
+      -m k \
+      -d ${GENBANK_ACCESSION}-seqsero2-assembly-kmer-mode \
+      -n ${GENBANK_ACCESSION} \
+      -p 2 && \
+    grep 'Infantis' ${GENBANK_ACCESSION}-seqsero2-assembly-kmer-mode/SeqSero_result.txt
+
+# testing reads as input for the same Salmonella isolate
+# specifically the "allele" mode which does micro assembly first using SPAdes
+RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR608/003/SRR6082043/SRR6082043_1.fastq.gz && \
+    wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR608/003/SRR6082043/SRR6082043_2.fastq.gz && \
+    SeqSero2_package.py \
+      -i SRR6082043_1.fastq.gz SRR6082043_2.fastq.gz \
+      -t 2 \
+      -m a \
+      -d ${GENBANK_ACCESSION}-seqsero2-reads-allele-mode \
+      -n ${GENBANK_ACCESSION} \
+      -p 2 && \
+    grep 'Infantis' ${GENBANK_ACCESSION}-seqsero2-reads-allele-mode/SeqSero_result.txt
+
+# print help options, check dependencies, print version
+RUN SeqSero2_package.py --help && SeqSero2_package.py --check && SeqSero2_package.py --version

--- a/seqsero2/1.2.1/Dockerfile
+++ b/seqsero2/1.2.1/Dockerfile
@@ -114,10 +114,10 @@ RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR608/003/SRR6082043/SRR6082043_1.f
       -i SRR6082043_1.fastq.gz SRR6082043_2.fastq.gz \
       -t 2 \
       -m a \
-      -d ${GENBANK_ACCESSION}-seqsero2-reads-allele-mode \
-      -n ${GENBANK_ACCESSION} \
+      -d SRR6082043-seqsero2-reads-allele-mode \
+      -n SRR6082043 \
       -p 2 && \
-    grep 'Infantis' ${GENBANK_ACCESSION}-seqsero2-reads-allele-mode/SeqSero_result.txt
+    grep 'Infantis' SRR6082043-seqsero2-reads-allele-mode/SeqSero_result.txt
 
 # print help options, check dependencies, print version
 RUN SeqSero2_package.py --help && SeqSero2_package.py --check && SeqSero2_package.py --version

--- a/seqsero2/1.2.1/README.md
+++ b/seqsero2/1.2.1/README.md
@@ -1,0 +1,62 @@
+# SeqSero2 docker image
+
+> SeqSero2: Salmonella enterica serotype prediction from genome sequencing data
+
+Main tool : [SeqSero2](https://github.com/denglab/SeqSero2)
+
+Additional tools:
+
+- spades 3.15.3
+- ncbi-blast+ 2.6.0
+- python 2.7.17
+- python3 3.6.9
+- biopython 1.73
+- samtools 1.9
+- bedtools 2.26.0
+- SalmID 0.122
+- bwa 0.7.17-r1188
+- sra-toolkit 2.8.2
+
+## Example Usage
+
+```bash
+# paired end Illumina reads as input for allele mode
+$ SeqSero2_package.py \
+      -i SRR6082043_1.fastq.gz SRR6082043_2.fastq.gz \
+      -t 2 \
+      -m a \
+      -d SRR6082043-seqsero2-reads-allele-mode \
+      -n SRR6082043 \
+      -p 2
+[bam_sort_core] merging from 0 files and 2 in-memory blocks...
+building database...
+mapping...
+check samtools version: 1.9
+assembling...
+blasting... 
+
+Sample name:    SRR6082043
+Output directory:       /test/SRR6082043-seqsero2-reads-allele-mode
+Input files:    /test/SRR6082043_1.fastq.gz     /test/SRR6082043_2.fastq.gz
+O antigen prediction:   7
+H1 antigen prediction(fliC):    r
+H2 antigen prediction(fljB):    1,5
+Predicted identification:       Salmonella enterica subspecies enterica (subspecies I)
+Predicted antigenic profile:    7:r:1,5
+Predicted serotype:     Infantis
+Note:
+
+# genome assembly FASTA as input for kmer mode
+$ SeqSero2_package.py \
+      -i GCA_007765495.1.genomic.fna \
+      -t 4 \
+      -m k \
+      -d GCA_007765495.1-seqsero2-assembly-kmer-mode \
+      -n GCA_007765495.1 \
+      -p 2
+
+
+
+
+
+```

--- a/seqsero2/1.2.1/README.md
+++ b/seqsero2/1.2.1/README.md
@@ -54,9 +54,14 @@ $ SeqSero2_package.py \
       -d GCA_007765495.1-seqsero2-assembly-kmer-mode \
       -n GCA_007765495.1 \
       -p 2
-
-
-
-
-
+Sample name:    GCA_007765495.1
+Output directory:       /test/GCA_007765495.1-seqsero2-assembly-kmer-mode
+Input files:    GCA_007765495.1.genomic.fna
+O antigen prediction:   7
+H1 antigen prediction(fliC):    r
+H2 antigen prediction(fljB):    1,5
+Predicted identification:       Salmonella enterica subspecies enterica (subspecies I)
+Predicted antigenic profile:    7:r:1,5
+Predicted serotype:     Infantis
+Note:
 ```


### PR DESCRIPTION
Motivation for the PR - rare SeqSero2 failures when using "allele" mode which uses SPAdes to perform a "micro-assembly" of reads that map to serotype specific loci. Issue on this repo is #491 but fully described over on Theiagen's repo https://github.com/theiagen/public_health_bacterial_genomics/issues/171

My intention is to overwrite the existing docker image tags `staphb/seqsero2:latest` and `staphb/seqsero2:1.2.1`

Changes to dockerfile:
- SPAdes version upgraded from 3.9.0 to 3.15.3 which resolves the above issue
- modernized by adding `app` and `test` layers
- `test` layer now downloads a Salmonella serovar Infantis assembly and PE ILMN reads to test through SeqSero2. Test does not take too long to run, usually less than a minute or 2 depending on how slow the ENA FTP is
- `dockerfile.version` bumped to 2 since I'm editing an existing dockerfile
- updated my email address
- added `apt-get install --no-install-recommends` as well as a few additional dependencies
- added variables for major tools installed, added `ARG`'s at the top to track versions used

Rendered README.md can be viewed here: https://github.com/StaPH-B/docker-builds/tree/cjk-seqsero2-fix/seqsero2/1.2.1

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
