### PR TITLE
modernize shovill 1.1.0 dockerfile: add app & test layers; upgrade spades, pilon, samtools, trimmomatic

### DIFF
--- a/shovill/1.1.0/Dockerfile
+++ b/shovill/1.1.0/Dockerfile
@@ -14,7 +14,8 @@ ARG SKESA_VER="2.3.0"
 ARG MEGAHIT_VER="1.1.4"
 ARG VELVET_VER="1.2.10"
 ARG FLASH_VER="1.2.11"
-ARG PILON_VER="1.22"
+# also not sure if this upgraded pilon version is compatible, previously used 1.22
+ARG PILON_VER="1.24"
 
 LABEL base.image="ubuntu:xenial"
 LABEL dockerfile.version="3"

--- a/shovill/1.1.0/Dockerfile
+++ b/shovill/1.1.0/Dockerfile
@@ -1,18 +1,36 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial as app
+
+# ephemeral environmental variables that go away after building the image
+ARG SHOVILL_VER="1.1.0"
+ARG SPADES_VER="3.15.5"
+ARG SEQTK_VER="1.3"
+ARG KMC_VER="3.1.1"
+ARG LIGHTER_VER="1.1.1"
+ARG TRIMMOMATIC_VER="0.38"
+ARG BWA_VER="0.7.17"
+# not sure if a more recent samtools is compatible or not, previously used samtools 1.10
+ARG SAMTOOLS_VER="1.16.1"
+ARG SKESA_VER="2.3.0"
+ARG MEGAHIT_VER="1.1.4"
+ARG VELVET_VER="1.2.10"
+ARG FLASH_VER="1.2.11"
+ARG PILON_VER="1.22"
 
 LABEL base.image="ubuntu:xenial"
-LABEL container.version="2"
+LABEL dockerfile.version="3"
 LABEL software="Shovill"
 LABEL software.version="1.1.0"
 LABEL description="faster than SPAdes de novo DBG genome assembler (with assembler options!)"
 LABEL website="https://github.com/tseemann/shovill"
 LABEL lisence="https://github.com/tseemann/shovill/blob/master/LICENSE"
 LABEL maintainer="Curtis Kapsak"
-LABEL maintainer.email="pjx8@cdc.gov"
+LABEL maintainer.email="kapsakcj@gmail.com"
 
 # install dependencies, cleanup apt garbage
-RUN apt-get update && apt-get install -y python \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python \
   wget \
+  ca-certificates \
   pigz \
   zlib1g-dev \
   make \
@@ -29,111 +47,110 @@ RUN apt-get update && apt-get install -y python \
   libssl-dev \
   libfindbin-libs-perl && \
   apt-get clean && apt-get autoclean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rfv /var/lib/apt/lists/*
 
 # SPAdes
-ENV spadesVer=3.14.1
-RUN wget https://github.com/ablab/spades/releases/download/v${spadesVer}/SPAdes-${spadesVer}-Linux.tar.gz && \
-  tar -xzf SPAdes-${spadesVer}-Linux.tar.gz && \
-  rm SPAdes-${spadesVer}-Linux.tar.gz
+RUN wget https://github.com/ablab/spades/releases/download/v${SPADES_VER}/SPAdes-${SPADES_VER}-Linux.tar.gz && \
+  tar -xzf SPAdes-${SPADES_VER}-Linux.tar.gz && \
+  rm -v SPAdes-${SPADES_VER}-Linux.tar.gz
 
-# Seqtk 1.3
-RUN mkdir seqtk && \ 
+# Seqtk install
+RUN mkdir -v seqtk && \ 
   cd seqtk && \
-  wget https://github.com/lh3/seqtk/archive/v1.3.tar.gz && \
-  tar -zxf v1.3.tar.gz && \
-  rm v1.3.tar.gz && \
-  cd seqtk-1.3/ && \
+  wget https://github.com/lh3/seqtk/archive/v${SEQTK_VER}.tar.gz && \
+  tar -zxf v${SEQTK_VER}.tar.gz && \
+  rm -v v${SEQTK_VER}.tar.gz && \
+  cd seqtk-${SEQTK_VER}/ && \
   make && \
   make install
 
 # kmc
 RUN mkdir kmc && \
   cd kmc && \
-  wget https://github.com/refresh-bio/KMC/releases/download/v3.1.1/KMC3.1.1.linux.tar.gz && \
-  tar -xzf KMC3.1.1.linux.tar.gz && \
-  rm KMC3.1.1.linux.tar.gz  
+  wget https://github.com/refresh-bio/KMC/releases/download/v${KMC_VER}/KMC${KMC_VER}.linux.tar.gz && \
+  tar -xzf KMC${KMC_VER}.linux.tar.gz && \
+  rm -v KMC${KMC_VER}.linux.tar.gz  
 
-# lighter 1.1.1
-RUN wget https://github.com/mourisl/Lighter/archive/v1.1.1.tar.gz && \
-  tar -zxf v1.1.1.tar.gz && \
-  rm -rf v1.1.1.tar.gz && \
-  cd Lighter-1.1.1 && \
+# lighter
+RUN wget https://github.com/mourisl/Lighter/archive/v${LIGHTER_VER}.tar.gz && \
+  tar -zxf v${LIGHTER_VER}.tar.gz && \
+  rm -rvf v${LIGHTER_VER}.tar.gz && \
+  cd Lighter-${LIGHTER_VER} && \
   make
 
-# trimmomatic 0.38
+# trimmomatic
 RUN mkdir trimmomatic && \
   cd trimmomatic && \
-  wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.38.zip && \
-  unzip Trimmomatic-0.38.zip && \
-  rm -rf Trimmomatic-0.38.zip && \
-  chmod +x Trimmomatic-0.38/trimmomatic-0.38.jar && \
+  wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-${TRIMMOMATIC_VER}.zip && \
+  unzip Trimmomatic-${TRIMMOMATIC_VER}.zip && \
+  rm -rf Trimmomatic-${TRIMMOMATIC_VER}.zip && \
+  chmod +x Trimmomatic-${TRIMMOMATIC_VER}/trimmomatic-${TRIMMOMATIC_VER}.jar && \
   echo "#!/bin/bash" >> trimmomatic && \
-  echo "exec java -jar /trimmomatic/Trimmomatic-0.38/trimmomatic-0.38.jar """"$""@"""" " >> trimmomatic && \
+  echo "exec java -jar /trimmomatic/Trimmomatic-${TRIMMOMATIC_VER}/trimmomatic-${TRIMMOMATIC_VER}.jar """"$""@"""" " >> trimmomatic && \
   chmod +x trimmomatic
 
-# bwa (mem) 0.7.17
+# bwa (mem) install
 RUN mkdir bwa && \
   cd bwa && \
-  wget https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 && \
-  tar -xjf bwa-0.7.17.tar.bz2 && \
-  rm bwa-0.7.17.tar.bz2 && \
-  cd bwa-0.7.17 && \
+  wget https://github.com/lh3/bwa/releases/download/v${BWA_VER}/bwa-${BWA_VER}.tar.bz2 && \
+  tar -xjf bwa-${BWA_VER}.tar.bz2 && \
+  rm bwa-${BWA_VER}.tar.bz2 && \
+  cd bwa-${BWA_VER} && \
   make
 
-# samtools 1.10 
+# samtools install 
 RUN mkdir samtools && \
   cd samtools && \
-  wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2 && \
-  tar -xjf samtools-1.10.tar.bz2 && \
-  rm samtools-1.10.tar.bz2 && \
-  cd samtools-1.10 && \
+  wget https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VER}/samtools-${SAMTOOLS_VER}.tar.bz2 && \
+  tar -xjf samtools-${SAMTOOLS_VER}.tar.bz2 && \
+  rm samtools-${SAMTOOLS_VER}.tar.bz2 && \
+  cd samtools-${SAMTOOLS_VER} && \
   ./configure && \
   make && \
   make install
 
-# skesa 2.3.0 (skesa 2.4.0 binary works better on ubuntu:bionic, so not upgrading here)
+# skesa 2.3.0 binary (skesa 2.4.0 binary works better on ubuntu:bionic, so not upgrading here)
 RUN mkdir skesa && \
   cd skesa && \
-  wget https://github.com/ncbi/SKESA/releases/download/v2.3.0/skesa.centos6.10 && \
+  wget https://github.com/ncbi/SKESA/releases/download/v${SKESA_VER}/skesa.centos6.10 && \
   mv skesa.centos6.10 skesa && \
   chmod +x skesa
 
 # MEGAHIT 1.1.4 binary (I'm pretty sure these are binaries at this point)
 RUN mkdir megahit && \
   cd megahit && \
-  wget https://github.com/voutcn/megahit/releases/download/v1.1.4/megahit_v1.1.4_LINUX_CPUONLY_x86_64-bin.tar.gz && \
-  tar -xzf megahit_v1.1.4_LINUX_CPUONLY_x86_64-bin.tar.gz && \
-  rm megahit_v1.1.4_LINUX_CPUONLY_x86_64-bin.tar.gz
+  wget https://github.com/voutcn/megahit/releases/download/v${MEGAHIT_VER}/megahit_v${MEGAHIT_VER}_LINUX_CPUONLY_x86_64-bin.tar.gz && \
+  tar -xzf megahit_v${MEGAHIT_VER}_LINUX_CPUONLY_x86_64-bin.tar.gz && \
+  rm megahit_v${MEGAHIT_VER}_LINUX_CPUONLY_x86_64-bin.tar.gz
 
 # Velvet 1.2.10
 RUN mkdir velvet && \
   cd velvet && \
-  wget https://github.com/dzerbino/velvet/archive/v1.2.10.tar.gz && \
-  tar -xzf v1.2.10.tar.gz && \
-  rm -rf v1.2.10.tar.gz && \
-  cd velvet-1.2.10 && \
+  wget https://github.com/dzerbino/velvet/archive/v${VELVET_VER}.tar.gz && \
+  tar -xzf v${VELVET_VER}.tar.gz && \
+  rm -rf v${VELVET_VER}.tar.gz && \
+  cd velvet-${VELVET_VER} && \
   make
 
 # Flash 1.2.11
 RUN mkdir flash && \
   cd flash && \
-  wget https://sourceforge.net/projects/flashpage/files/FLASH-1.2.11.tar.gz && \
-  tar -zxf FLASH-1.2.11.tar.gz && \
-  rm -rf FLASH-1.2.11.tar.gz && \
-  cd FLASH-1.2.11 && \
+  wget https://sourceforge.net/projects/flashpage/files/FLASH-${FLASH_VER}.tar.gz && \
+  tar -zxf FLASH-${FLASH_VER}.tar.gz && \
+  rm -rf FLASH-${FLASH_VER}.tar.gz && \
+  cd FLASH-${FLASH_VER} && \
   make
 
-# pilon 1.22
+# pilon
 RUN mkdir pilon && \
   cd pilon && \
-  wget https://github.com/broadinstitute/pilon/releases/download/v1.22/pilon-1.22.jar && \
-  chmod +x pilon-1.22.jar && \
+  wget https://github.com/broadinstitute/pilon/releases/download/v${PILON_VER}/pilon-${PILON_VER}.jar && \
+  chmod +x pilon-${PILON_VER}.jar && \
   echo "#!/bin/bash" >> pilon && \
-  echo "exec java -jar /pilon/pilon-1.22.jar """"$""@"""" " >> pilon && \
+  echo "exec java -jar /pilon/pilon-${PILON_VER}.jar """"$""@"""" " >> pilon && \
   chmod +x pilon
 
-# Samclip
+# Samclip (not going to pin a version, this is the recommended way of installing and there have not been updates since March 2020)
 RUN mkdir samclip && \
   cd samclip && \
   wget https://raw.githubusercontent.com/tseemann/samclip/master/samclip && \
@@ -144,26 +161,31 @@ RUN mkdir samclip && \
 # create /data for working directory
 RUN mkdir shovill && \
   cd shovill && \
-  wget https://github.com/tseemann/shovill/archive/v1.1.0.tar.gz && \
-  tar -xzf v1.1.0.tar.gz && \
-  rm v1.1.0.tar.gz && \
+  wget https://github.com/tseemann/shovill/archive/v${SHOVILL_VER}.tar.gz && \
+  tar -xzf v${SHOVILL_VER}.tar.gz && \
+  rm v${SHOVILL_VER}.tar.gz && \
   mkdir /data
 
-# set /data as working directory
+# set /data as final working directory
 WORKDIR /data
 
 # set $PATH's
 ENV PATH="${PATH}:\
-/SPAdes-${spadesVer}-Linux/bin:\
+/SPAdes-${SPADES_VER}-Linux/bin:\
 /kmc:\
-/Lighter-1.1.1:\
+/Lighter-${LIGHTER_VER}:\
 /trimmomatic:\
-/bwa/bwa-0.7.17:\
+/bwa/bwa-${BWA_VER}:\
 /skesa:\
-/megahit/megahit_v1.1.4_LINUX_CPUONLY_x86_64-bin:\
-/velvet/velvet-1.2.10:\
-/flash/FLASH-1.2.11:\
-/shovill/shovill-1.1.0/bin:\
+/megahit/megahit_v${MEGAHIT_VER}_LINUX_CPUONLY_x86_64-bin:\
+/velvet/velvet-${VELVET_VER}:\
+/flash/FLASH-${FLASH_VER}:\
+/shovill/shovill-${SHOVILL_VER}/bin:\
 /pilon:\
 /samclip"\
      LC_ALL=C
+
+# test layer
+FROM app as test
+
+RUN shovill --help && shovill --check

--- a/shovill/1.1.0/Dockerfile
+++ b/shovill/1.1.0/Dockerfile
@@ -214,7 +214,6 @@ SHELL ["/bin/bash", "-c"]
 RUN cd /shovill/shovill-${SHOVILL_VER}/ && \
 kmc && \
 skesa --version && \
-shovill --version && \
 ! shovill --doesnotexist && \
 echo "TESTING SHOVILL + SPADES" && \
 shovill --outdir out.spades --assembler spades --R1 test/R1.fq.gz --R2 test/R2.fq.gz --nostitch --noreadcorr --nocorr && \
@@ -229,4 +228,4 @@ echo "TESTING SHOVILL + SKESA" && \
 shovill --outdir out.skesa --assembler skesa --R1 test/R1.fq.gz --R2 test/R2.fq.gz --ram 4 --noreadcorr --nocorr && \
 grep '>' out.velvet/contigs.fa
 
-RUN shovill --help && shovill --check
+RUN shovill --help && shovill --check && shovill --version

--- a/shovill/1.1.0/Dockerfile
+++ b/shovill/1.1.0/Dockerfile
@@ -4,7 +4,7 @@ ARG SPADES_VER="3.15.5"
 ARG SEQTK_VER="1.3"
 ARG KMC_VER="3.1.1"
 ARG LIGHTER_VER="1.1.1"
-ARG TRIMMOMATIC_VER="0.38"
+ARG TRIMMOMATIC_VER="0.39"
 ARG BWA_VER="0.7.17"
 # not sure if a more recent samtools is compatible or not, previously used samtools 1.10
 ARG SAMTOOLS_VER="1.16.1"
@@ -175,9 +175,7 @@ RUN mkdir samclip && \
 # aaannnddd finally install shovill v1.1.0 itself
 # extra perl module I had to install via apt-get: libfindbin-libs-perl
 # create /data for working directory
-RUN mkdir shovill && \
-  cd shovill && \
-  wget https://github.com/tseemann/shovill/archive/v${SHOVILL_VER}.tar.gz && \
+RUN wget https://github.com/tseemann/shovill/archive/v${SHOVILL_VER}.tar.gz && \
   tar -xzf v${SHOVILL_VER}.tar.gz && \
   rm v${SHOVILL_VER}.tar.gz && \
   mkdir /data
@@ -196,7 +194,7 @@ ENV PATH="${PATH}:\
 /megahit/megahit_v${MEGAHIT_VER}_LINUX_CPUONLY_x86_64-bin:\
 /velvet/velvet-${VELVET_VER}:\
 /flash/FLASH-${FLASH_VER}:\
-/shovill/shovill-${SHOVILL_VER}/bin:\
+/shovill-${SHOVILL_VER}/bin:\
 /pilon:\
 /samclip"\
      LC_ALL=C
@@ -211,7 +209,7 @@ ARG SHOVILL_VER
 SHELL ["/bin/bash", "-c"]
 
 # test shamelessly stolen & modified from: https://github.com/tseemann/shovill/blob/master/.travis.yml
-RUN cd /shovill/shovill-${SHOVILL_VER}/ && \
+RUN cd /shovill-${SHOVILL_VER}/ && \
 kmc && \
 skesa --version && \
 ! shovill --doesnotexist && \

--- a/shovill/1.1.0/Dockerfile
+++ b/shovill/1.1.0/Dockerfile
@@ -1,5 +1,3 @@
-FROM ubuntu:xenial as app
-
 # ephemeral environmental variables that go away after building the image
 ARG SHOVILL_VER="1.1.0"
 ARG SPADES_VER="3.15.5"
@@ -16,6 +14,23 @@ ARG VELVET_VER="1.2.10"
 ARG FLASH_VER="1.2.11"
 # also not sure if this upgraded pilon version is compatible, previously used 1.22
 ARG PILON_VER="1.24"
+
+FROM ubuntu:xenial as app
+
+# reinstantiating variables so they are available in app FROM layer
+ARG SHOVILL_VER
+ARG SPADES_VER
+ARG SEQTK_VER
+ARG KMC_VER
+ARG LIGHTER_VER
+ARG TRIMMOMATIC_VER
+ARG BWA_VER
+ARG SAMTOOLS_VER
+ARG SKESA_VER
+ARG MEGAHIT_VER
+ARG VELVET_VER
+ARG FLASH_VER
+ARG PILON_VER
 
 LABEL base.image="ubuntu:xenial"
 LABEL dockerfile.version="3"
@@ -188,5 +203,30 @@ ENV PATH="${PATH}:\
 
 # test layer
 FROM app as test
+
+# reinstantiating variable so it's available for cd cmd below
+ARG SHOVILL_VER
+
+# so that the below commands are run with /bin/bash shell and not /bin/sh - needed for bash-specific tricks below
+SHELL ["/bin/bash", "-c"]
+
+# test shamelessly stolen & modified from: https://github.com/tseemann/shovill/blob/master/.travis.yml
+RUN cd /shovill/shovill-${SHOVILL_VER}/ && \
+kmc && \
+skesa --version && \
+shovill --version && \
+! shovill --doesnotexist && \
+echo "TESTING SHOVILL + SPADES" && \
+shovill --outdir out.spades --assembler spades --R1 test/R1.fq.gz --R2 test/R2.fq.gz --nostitch --noreadcorr --nocorr && \
+grep '>' out.spades/contigs.fa && \
+echo "TESTING SHOVILL + MEGAHIT" && \
+shovill --outdir out.megahit --assembler megahit --R1 test/R1.fq.gz --R2 test/R2.fq.gz --trim && \
+grep '>' out.megahit/contigs.fa && \
+echo "TESTING SHOVILL + VELVET" && \
+shovill --outdir out.velvet --assembler velvet --R1 test/R1.fq.gz --R2 test/R2.fq.gz --ram 4 --noreadcorr --nocorr && \
+grep '>' out.velvet/contigs.fa && \
+echo "TESTING SHOVILL + SKESA" && \
+shovill --outdir out.skesa --assembler skesa --R1 test/R1.fq.gz --R2 test/R2.fq.gz --ram 4 --noreadcorr --nocorr && \
+grep '>' out.velvet/contigs.fa
 
 RUN shovill --help && shovill --check

--- a/shovill/1.1.0/README.md
+++ b/shovill/1.1.0/README.md
@@ -1,0 +1,46 @@
+# Shovill v1.1.0 docker image
+
+Main tool : [Shovill](https://github.com/tseemann/shovill)
+
+Additional tools:
+
+- SPAdes 3.15.5
+- SKESA 2.3.0
+- megahit 1.1.4
+- velvet 1.2.10
+- seqtk 1.3
+- kmc 3.1.1
+- lighter 1.1.1
+- trimmomatic 0.39
+- bwa 0.7.17
+- pilon 1.24
+- samclip
+- perl 5.22.1
+- python 2.7.12
+- pigz
+
+Full documentation: [https://github.com/tseemann/shovill](https://github.com/tseemann/shovill)
+
+> *Assemble bacterial isolate genomes from Illumina paired-end reads*
+
+## NOTE ON DEC 2022 UPGRADES
+
+The Shovill 1.1.0 docker image was originally developed in May 2020 using this the version of the dockerfile, [commit 615d1cfeb4](https://github.com/StaPH-B/docker-builds/blob/615d1cfeb464df4635b2efbe1b359351c5b5b0f7/shovill/1.1.0/Dockerfile)
+
+This older docker image will be maintained under this docker image tag: `staphb/shovill:1.1.0`
+
+The Shovill docker image has since been upgraded via [Pull Request #511](https://github.com/StaPH-B/docker-builds/pull/511) which upgraded the following tools in the shovill 1.1.0 dockerfile. Other smaller changes were also introduced (see the PR for details)
+
+- upgraded spades from 3.14.1 to 3.15.5
+- upgraded pilon from 1.22 to 1.24
+- upgraded samtools from 1.10 to 1.16.1
+- upgraded trimmomatic from 0.38 to 0.39
+
+This newer docker image will be maintained under the docker image tags: `staphb/shovill:1.1.0-2022Dec` & `staphb/shovill:latest` in an effort to preserve the older docker image & allow for users to more easily transition to the new docker image in their pipelines.
+
+### Example Usage
+
+```bash
+# run shovill on the test FASTQ files bundled with shovill
+shovill --outdir /data/out.spades --assembler spades --R1 /shovill-1.1.0/test/R1.fq.gz --R2 /shovill-1.1.0/test/R2.fq.gz
+```


### PR DESCRIPTION
~~Setting as a draft for now, until I can do more thorough testing.~~ ~~I would like to do more thorough testing before merging this PR &~~ overwriting the existing `staphb/shovill:latest` & ~~`staphb/shovill:1.1.0`~~ docker images

READY FOR REVIEW

I changed my mind, I would like to create a new custom docker image tag for this new dockerfile version, in an effort to preserve the existing shovill 1.1.0 docker image. I propose overwriting `staphb/shovill:latest` tag as well as creating a new one: `staphb/shovill:1.1.0-2022Dec`

todos:
- [x] add `shovill/1.1.0/README.md` - [view rendered README.md here](https://github.com/StaPH-B/docker-builds/tree/cjk-update-shovill-1.1.0/shovill/1.1.0)
- [x] test thoroughly with many samples (100+)
 
⬆️  tested by assembling 251 illumina paired end samples of various bacterial taxon, mostly enterics - Salmonella, E. coli, Listeria, Campy, etc. Shovill docker image ran as expected with skesa as the underlying assembler. Also tested the same 251 samples with spades as the underlying assembler, all ran as expected ✔️ 

This PR addresses #508 to update the version of spades included with shovill 1.1.0.

Changes:
- added `ARG`'s for almost all dependencies installed, updated install cmds to use these variables instead of hardcoding
- added `app` and `test` layers 
  - `test` layer does dependency checking `shovill --check` and assembles shovill-bundled test data with each of 4 assembler options
- upgraded spades from 3.14.1 to 3.15.5
- upgraded pilon from 1.22 to 1.24
- upgraded samtools from 1.10 to 1.16.1
- upgraded trimmomatic from 0.38 to 0.39
- added `apt-get install --no-install-recommends` as well as added `ca-certificates` to list of stuff installed via `apt-get`
- added `rm -v` & `mkdir -v` flag throughout most of the commands to know when something is removed or a dir is created. (I probably missed a few)

Other potential changes to add? Thoughts?

- ~~upgrade trimmomatic version~~ Done.

I've pushed the docker image to my personal dockerhub if you'd like to test it: `kapsakcj/shovill:1.1.0-updated-spades`

https://hub.docker.com/r/kapsakcj/shovill/tags

Passes the dependency check and I've assembled at least one Salmonella enterica sample successfully with both spades and skesa.

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
