### PR TITLE
updated ngmaster 1.0.0 dockerfile (for bug fix) and README.md

### DIFF
--- a/ngmaster/1.0.0/Dockerfile
+++ b/ngmaster/1.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.2.0 as app
+FROM mambaorg/micromamba:1.3.0 as app
 
 # build and run as root users since micromamba image has 'mambauser' set as the $USER
 USER root
@@ -10,7 +10,7 @@ ARG NGMASTER_VER="1.0.0"
 ARG MLST_VER="2.23.0"
 ARG ANY2FASTA_VER="0.4.2"
 
-LABEL base.image="mambaorg/micromamba:1.2.0"
+LABEL base.image="mambaorg/micromamba:1.3.0"
 LABEL dockerfile.version="2"
 LABEL software="ngmaster"
 LABEL software.version=${NGMASTER_VER}
@@ -42,7 +42,7 @@ ENV ENV_NAME="base"
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # hardcode conda env into the PATH; set locale settings
-ENV PATH="${PATH}:/opt/conda/bin" \
+ENV PATH="/opt/conda/bin:${PATH}" \
  LC_ALL=C.UTF-8
 
 # set final & default working dir to /data

--- a/ngmaster/1.0.0/Dockerfile
+++ b/ngmaster/1.0.0/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update && apt-get install unzip curl ca-certificates -y --no-install
 WORKDIR /test
 
 # test with an actual assembly downloaded from RefSeq
+# more info on this genome here: https://www.ncbi.nlm.nih.gov/labs/data-hub/genome/GCF_013030075.1/
 RUN curl -OJX GET "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/accession/GCF_013030075.1/download?include_annotation_type=GENOME_FASTA,GENOME_GFF,RNA_FASTA,CDS_FASTA,PROT_FASTA,SEQUENCE_REPORT&filename=GCF_013030075.1.zip" \
  -H "Accept: application/zip" && \
  unzip GCF_013030075.1.zip && \

--- a/ngmaster/1.0.0/Dockerfile
+++ b/ngmaster/1.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:0.27.0 as app
+FROM mambaorg/micromamba:1.2.0 as app
 
 # build and run as root users since micromamba image has 'mambauser' set as the $USER
 USER root
@@ -10,8 +10,8 @@ ARG NGMASTER_VER="1.0.0"
 ARG MLST_VER="2.23.0"
 ARG ANY2FASTA_VER="0.4.2"
 
-LABEL base.image="mambaorg/micromamba:0.27.0"
-LABEL dockerfile.version="1"
+LABEL base.image="mambaorg/micromamba:1.2.0"
+LABEL dockerfile.version="2"
 LABEL software="ngmaster"
 LABEL software.version=${NGMASTER_VER}
 LABEL description="In silico multi-antigen sequence typing for Neisseria gonorrhoeae (NG-MAST)"
@@ -26,10 +26,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  procps && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-# create conda env 'ngmaster-env' and install python, pip, biopython, isPcr version 33;
+# install python, pip, biopython, isPcr version 33 into base micromamba env
 # cleanup conda garbage
-RUN micromamba create -n ngmaster-env -c bioconda -c conda-forge -c defaults \
- python>=3.7 \
+RUN micromamba install -n base -c conda-forge -c bioconda -c defaults \
+ 'python>=3.7' \
  pip \
  biopython \
  any2fasta=${ANY2FASTA_VER} \
@@ -38,14 +38,11 @@ RUN micromamba create -n ngmaster-env -c bioconda -c conda-forge -c defaults \
  micromamba clean -a -y
 
 # so that mamba/conda env is active when running below commands
-ENV ENV_NAME="ngmaster-env"
+ENV ENV_NAME="base"
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
-# install ngmaster via pypi; using pip installed via micromamba
-#RUN pip install ngmaster==${NGMASTER_VER}
-
 # hardcode conda env into the PATH; set locale settings
-ENV PATH="${PATH}:/opt/conda/envs/ngmaster-env/bin/" \
+ENV PATH="${PATH}:/opt/conda/bin" \
  LC_ALL=C.UTF-8
 
 # set final & default working dir to /data
@@ -55,10 +52,23 @@ WORKDIR /data
 FROM app as test
 
 # so that mamba/conda env is active when running below commands
-ENV ENV_NAME="ngmaster-env"
+ENV ENV_NAME="base"
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # show help and version outputs; run the program's internal tests
 RUN ngmaster --help && echo && \
  ngmaster --version && mlst --version && echo && \
  ngmaster --test
+
+# getting unzip for unziping archive downloaded from NCBI
+RUN apt-get update && apt-get install unzip curl ca-certificates -y --no-install-recommends
+
+# so that testing outputs are in /test
+WORKDIR /test
+
+# test with an actual assembly downloaded from RefSeq
+RUN curl -OJX GET "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/accession/GCF_013030075.1/download?include_annotation_type=GENOME_FASTA,GENOME_GFF,RNA_FASTA,CDS_FASTA,PROT_FASTA,SEQUENCE_REPORT&filename=GCF_013030075.1.zip" \
+ -H "Accept: application/zip" && \
+ unzip GCF_013030075.1.zip && \
+ ngmaster /test/ncbi_dataset/data/GCF_013030075.1/GCF_013030075.1_ASM1303007v1_genomic.fna > ngmaster.out.tsv && \
+ cat /test/ngmaster.out.tsv

--- a/ngmaster/1.0.0/README.md
+++ b/ngmaster/1.0.0/README.md
@@ -9,9 +9,9 @@ Additional tools:
 - any2fasta 0.4.2
 - mlst 2.23.0
 - python 3.9.0
-- biopython 1.79
+- biopython 1.80
 - perl 5.32.1
-- bioperl 1.80
+- bioperl 1.7.9
 
 ## Example Usage
 

--- a/ngmaster/1.0.0/README.md
+++ b/ngmaster/1.0.0/README.md
@@ -8,15 +8,16 @@ Additional tools:
 
 - any2fasta 0.4.2
 - mlst 2.23.0
-- python 3.7.12
+- python 3.9.0
 - biopython 1.79
 - perl 5.32.1
-- bioperl 1.7.8
+- bioperl 1.80
 
 ## Example Usage
 
 ```bash
-$ ngmaster /opt/conda/envs/ngmaster-env/lib/python3.7/site-packages/ngmaster/test/test.fa
+# test ngmaster with the test FASTA file included with ngmaster code
+$ ngmaster /opt/conda/lib/python3.9/site-packages/ngmaster/test/test.fa
 FILE    SCHEME  NG-MAST/NG-STAR porB_NG-MAST    tbpB    penA    mtrR    porB_NG-STAR    ponA    gyrA    parC    23S
-/opt/conda/envs/ngmaster-env/lib/python3.7/site-packages/ngmaster/test/test.fa  ngmaSTar        4186/231        2569    241     23      42      100     100     10      2       100
+/opt/conda/lib/python3.9/site-packages/ngmaster/test/test.fa    ngmaSTar        4186/231        2569    241     23      42      100     100     10      2100
 ```


### PR DESCRIPTION
~~__I want to test a bit more before merging this PR, NOT YET READY FOR REVIEW! PLEASE HOLD__~~

__Ready for review__

Docker image available here for testing on my personal dockerhub: https://hub.docker.com/r/kapsakcj/ngmaster
`kapsakcj/ngmaster:1.0.0`

Updated the ngmaster dockerfile for a bug fix plus a few extra improvements

~~The bug: PATH variable was set with a `/` at the end `${PATH}:/opt/conda/envs/ngmaster-env/bin/`, causing PATH issues when calling `mlst`:~~

I no longer thing the trailing `/` slash caused this issue (shown below), but I'm also not entirely sure what caused it. After making the changes in this PR and testing with the same assembly, `ngmaster` ran successfully.
```
Command '['/opt/conda/envs/ngmaster-env/bin//mlst', '--legacy', '-q', '--threads', '16', '--datadir', '/opt/conda/envs/ngmaster-env/lib/python3.7/site-packages/ngmaster/db/pubmlst', '--blastdb', '/opt/conda/envs/ngmaster-env/lib/python3.7/site-packages/ngmaster/db/blast/mlst.fa', '--scheme', 'ngmast', '--minid', '95', '--mincov', '10', '/mnt/miniwdl_task_container/work/_miniwdl_inputs/0/19AC0002348_contigs.fasta']' returned non-zero exit status 2.
```

Changes to dockerfile:

- upgraded base image to `mambaorg/micromamba:1.3.0`
- bumped `dockerfile.version="2"` since I'm editing a pre-existing dockerfile
- install tools into `base` micromamba env instead of creating a custom one called `ngmaster-env`. Much simpler this way
- re-ordered conda channels so that `conda-forge` is prioritized over `bioconda`
- fixed the python=>3.7 version pinning in `micromamba install` command
- updated PATH to appropriate conda env and removed trailing `/`
- Added test where a reference genome is downloaded from NCBI & run through `ngmaster`

Also updated `ngmaster/1.0.0/README.md` to reflect new dependencies and location of test FASTA

Docker image builds successfully and tests fine

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
