### PR TITLE
phyml bug fix

### DIFF
--- a/phyml/3.3.20220408/Dockerfile
+++ b/phyml/3.3.20220408/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer.email="jvhagey@gmail.com"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update &&\
     apt-get install -y --no-install-recommends \
-        ca-certificates=20210119~20.04.2 \
+        ca-certificates \
         pkg-config=0.29.1-0ubuntu4 \
         automake=1:1.16.1-4ubuntu6 \
         autoconf=2.69-11.1 \

--- a/phyml/3.3.20220408/Dockerfile
+++ b/phyml/3.3.20220408/Dockerfile
@@ -5,7 +5,7 @@ ARG PHYML_VER="3.3.20220408"
 
 # metadata
 LABEL base.image="ubuntu:focal"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="Phyml"
 LABEL software.version="3.3.20220408"
 LABEL description="PhyML estimates maximum likelihood phylogenies from alignments of nucleotide or amino acid sequences."


### PR DESCRIPTION
Quick PR to address issue #589 

Please do not use the GHActions workflow to deploy this docker image - I have a feeling that the code compile install steps might behave differently on GHActions runners versus my local VM based on the CPU architecture on each.

Since the one I built locally resolved the issue for Jill on multiple servers, I think it's best if I build the image locally and push to dockerhub and quay locally as well.

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
