### PR TITLE
added pigz to spades 3.15.5 dockerfile to address issue 592

### DIFF
--- a/spades/3.15.5/Dockerfile
+++ b/spades/3.15.5/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal as app
 ARG SPADES_VER="3.15.5"
 
 LABEL base.image="ubuntu:focal"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="SPAdes"
 LABEL software.version="${SPADES_VER}"
 LABEL description="de novo DBG genome assembler"

--- a/spades/3.15.5/Dockerfile
+++ b/spades/3.15.5/Dockerfile
@@ -18,7 +18,8 @@ LABEL maintainer.email="kapsakcj@gmail.com"
 RUN apt-get update && apt-get install --no-install-recommends -y python3 \
  python3-distutils \
  wget \
- pigz && \
+ pigz \
+ ca-certificates && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/* && \
  update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 

--- a/spades/3.15.5/Dockerfile
+++ b/spades/3.15.5/Dockerfile
@@ -17,7 +17,8 @@ LABEL maintainer.email="kapsakcj@gmail.com"
 # python v3.8.10 is installed here; point 'python' to python3
 RUN apt-get update && apt-get install --no-install-recommends -y python3 \
  python3-distutils \
- wget && \
+ wget \
+ pigz && \
  apt-get autoclean && rm -rf /var/lib/apt/lists/* && \
  update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 


### PR DESCRIPTION
Adds `pigz` to the SPAdes container to address #592 

Also added `ca-certificates` to pass the syntax check.

I've pushed the image to my personal dockerhub repo for testing: `kapsakcj/spades:3.15.5` https://hub.docker.com/r/kapsakcj/spades/tags

~~Setting as a draft until we're satisfied with the changes & functionality~~

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing


<!-- If this PR is for something else, please add extra descriptions -->
