### PR TITLE
add python3 to lyveset 1.1.4f dockerfile - for output parsing purposes

### DIFF
--- a/lyveset/1.1.4f/Dockerfile
+++ b/lyveset/1.1.4f/Dockerfile
@@ -48,7 +48,8 @@ RUN apt update && apt-get install -y \
     libio-socket-ssl-perl \
     libxml-simple-perl \
     unzip \
-    smalt &&\
+    smalt \
+    python3 &&\
     apt-get clean && apt-get autoclean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/lyveset/1.1.4f/README.md
+++ b/lyveset/1.1.4f/README.md
@@ -3,8 +3,10 @@
 Main tool: [Lyve-SET](https://github.com/lskatz/Lyve-SET)
 
 Additional tools:
+
 - ncbi-blast+ 2.2.31
 - python 2.7.12
+- python 3.5.2
 - bioperl 1.6.924
 - cpanminus 1.7040
 - NCBI E-utilities


### PR DESCRIPTION
`python3` was inadvertently removed from the lyveset 1.1.4f dockerfile in PR #582 . This caused some of our pipelines to break since we use python3 in this container to parse outputs from cg-pipeline scripts.

I would be most appreciative if we could merge this soon & re-deploy the docker images to dockerhub and quay

This PR simply adds `python3` to the list of packages installed via `apt-get`. Everything else is identical and the tests run successfully 

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing

