### PR TITLE
gnuplot with mummer

### DIFF
--- a/mummer/4.0.0-RGDv2/Dockerfile
+++ b/mummer/4.0.0-RGDv2/Dockerfile
@@ -11,8 +11,8 @@ LABEL software.version=${MUMMER_VER}
 LABEL description="MUMmer is a versatile alignment tool for DNA and protein sequences."
 LABEL website="https://github.com/mummer4/mummer"
 LABEL license="https://github.com/mummer4/mummer/blob/master/LICENSE.md"
-LABEL maintainer1="John Arnn"
-LABEL maintainer1.email="jarnn@utah.gov"
+LABEL maintainer="John Arnn"
+LABEL maintainer.email="jarnn@utah.gov"
 LABEL maintaine2r="Curtis Kapsak"
 LABEL maintainer2.email="kapsakcj@gmail.com"
 
@@ -21,28 +21,29 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies via apt; clean up apt garbage
 RUN apt-get update && apt-get install -y --no-install-recommends \
- wget \
- git \
- libncurses5-dev \
- libbz2-dev \
- liblzma-dev \
- libcurl4-gnutls-dev \
- zlib1g-dev \
- libssl-dev \
- gcc \
- make \
- perl \
- bzip2 \
- gnuplot \
- ca-certificates \
- gawk \
- curl \
- sed \
- build-essential \
- unzip && \
- apt-get autoclean && rm -rf /var/lib/apt/lists/*
+  wget \
+  git \
+  libncurses5-dev \
+  libbz2-dev \
+  liblzma-dev \
+  libcurl4-gnutls-dev \
+  zlib1g-dev \
+  libssl-dev \
+  gcc \
+  make \
+  perl \
+  bzip2 \
+  gnuplot \
+  ca-certificates \
+  gawk \
+  curl \
+  sed \
+  gnuplot \
+  build-essential \
+  unzip && \
+  apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
- # install mummer; make /data for use as working directory
+# install mummer; make /data for use as working directory
 RUN wget https://github.com/mummer4/mummer/releases/download/v${MUMMER_VER}rc1/mummer-${MUMMER_VER}rc1.tar.gz && \
   tar -xvf mummer-${MUMMER_VER}rc1.tar.gz && \
   rm mummer-${MUMMER_VER}rc1.tar.gz && \
@@ -56,8 +57,8 @@ RUN wget https://github.com/mummer4/mummer/releases/download/v${MUMMER_VER}rc1/m
 
 # install ncbi datasets tool (pre-compiled binary); place in $PATH
 RUN wget https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/LATEST/linux-amd64/datasets && \
- chmod +x datasets && \
- mv -v datasets /usr/local/bin
+  chmod +x datasets && \
+  mv -v datasets /usr/local/bin
 
 # copy in list of NCBI accessions and species list
 COPY RGDv2-NCBI-assembly-accessions.txt /RGDv2/RGDv2-NCBI-assembly-accessions.txt
@@ -67,31 +68,31 @@ COPY RGDv2-NCBI-assembly-accessions-and-species.txt /RGDv2/RGDv2-NCBI-assembly-a
 # move and re-name assemblies to include Species in the filename
 # make fasta files readable to all users; create File Of FileNames for all 43 assemblies (to be used with fastANI)
 RUN for ID in $(cat /RGDv2/RGDv2-NCBI-assembly-accessions.txt); do \
- SPECIES=$(grep "${ID}" /RGDv2/RGDv2-NCBI-assembly-accessions-and-species.txt | cut -f 1) && \
- echo "downloading $ID, species "${SPECIES}", from NCBI..."; \
- datasets download genome accession --filename ${ID}.zip ${ID}; \
- unzip -q ${ID}.zip; \
- rm ${ID}.zip; \
- mv -v ncbi_dataset/data/${ID}/${ID}*.fna /RGDv2/${ID}.${SPECIES}.fasta; \
- rm -rf ncbi_dataset/; \
- rm README.md; \
-done && \
-ls /RGDv2/*.fasta >/RGDv2/FOFN-RGDv2.txt && \
-chmod 664 /RGDv2/*
+    SPECIES=$(grep "${ID}" /RGDv2/RGDv2-NCBI-assembly-accessions-and-species.txt | cut -f 1) && \
+    echo "downloading $ID, species "${SPECIES}", from NCBI..."; \
+    datasets download genome accession --filename ${ID}.zip ${ID}; \
+    unzip -q ${ID}.zip; \
+    rm ${ID}.zip; \
+    mv -v ncbi_dataset/data/${ID}/${ID}*.fna /RGDv2/${ID}.${SPECIES}.fasta; \
+    rm -rf ncbi_dataset/; \
+    rm README.md; \
+  done && \
+  ls /RGDv2/*.fasta >/RGDv2/FOFN-RGDv2.txt && \
+  chmod 664 /RGDv2/*
 
 # downloading mash binary
 RUN wget https://github.com/marbl/Mash/releases/download/v${MASH_VER}/mash-Linux64-v${MASH_VER}.tar && \
- tar -xvf mash-Linux64-v${MASH_VER}.tar && \
- rm -rf mash-Linux64-v${MASH_VER}.tar
+  tar -xvf mash-Linux64-v${MASH_VER}.tar && \
+  rm -rf mash-Linux64-v${MASH_VER}.tar
 
 # download Lee's ani-m script
 RUN wget https://github.com/lskatz/ani-m/archive/refs/tags/v0.1.tar.gz && \
- tar xzf v0.1.tar.gz && \
- rm -v v0.1.tar.gz
+  tar xzf v0.1.tar.gz && \
+  rm -v v0.1.tar.gz
 
 # LC_ALL for singularity compatibility; set PATH
 ENV LC_ALL=C \
- PATH="${PATH}:/ani-m-0.1:/mash-Linux64-v${MASH_VER}"
+  PATH="${PATH}:/ani-m-0.1:/mash-Linux64-v${MASH_VER}"
 
 # set working directory
 WORKDIR /data
@@ -114,11 +115,13 @@ RUN nucmer -h && nucmer --version && \
   mummerplot -x "[0,275287]" -y "[0,265111]" --terminal png -postscript -p mummer mummer.mums && \
   nucmer  -c 100 -p nucmer B_anthracis_Mslice.fasta B_anthracis_contigs.fasta && \
   show-snps -C nucmer.delta > nucmer.snps && \
-  promer -p promer_100 -c 100  H_pylori26695_Eslice.fasta H_pyloriJ99_Eslice.fasta
+  promer -p promer_100 -c 100  H_pylori26695_Eslice.fasta H_pyloriJ99_Eslice.fasta && \
+  mummerplot -l nucmer.delta -p test_mummer_plot --png && \
+  gnuplot test_mummer_plot.gp
 
 # testing ani-m.pl (which runs 'dnadiff' and 'mash' under the hood)
 # comparing one of the reference genomes to another
 RUN ani-m.pl --symmetric --mash-filter 0.9 \
- /RGDv2/GCA_014526935.1.Listeria_monocytogenes.fasta \
- /RGDv2/GCA_001466295.1.Listeria_monocytogenes.fasta \
- | tee test-output-ani-m.tsv
+  /RGDv2/GCA_014526935.1.Listeria_monocytogenes.fasta \
+  /RGDv2/GCA_001466295.1.Listeria_monocytogenes.fasta \
+  | tee test-output-ani-m.tsv

--- a/mummer/4.0.0-RGDv2/Dockerfile
+++ b/mummer/4.0.0-RGDv2/Dockerfile
@@ -5,7 +5,7 @@ ARG MUMMER_VER="4.0.0"
 ARG MASH_VER="2.3"
 
 LABEL base.image="ubuntu:focal"
-LABEL dockerfile.version="1"
+LABEL dockerfile.version="2"
 LABEL software="mummer"
 LABEL software.version=${MUMMER_VER}
 LABEL description="MUMmer is a versatile alignment tool for DNA and protein sequences."


### PR DESCRIPTION
A summary from a conversation on [slack](https://staph-b-dev.slack.com/archives/CBX7HREEM/p1677632173822549):

Arie Dash would like gnuplot to be included in the mummer container, specifically to do something like this

```
nucmer -p ~{samplename} ~{reference} ~{query}
mummerplot -l ~{samplename}.delta -p ~{samplename}_mummer_plot --png
gnuplot ~{samplename}_mummer_plot.gp
```
So I added it. I also added the gnuplot to the tests stage.

I also fixed the uneven tabs, which is why it looks like I rewrote the entire Dockerfile.

Pull Request (PR) checklist:
- [X] Include a description of what is in this pull request in this message.
- [X] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/samtools/1.15` )
- [X] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number (i.e. `spades/3.12.0/Dockerfile`)
   - [X] (optional) All test files are located in same directory as the Dockerfile (i.e. `shigatyper/2.0.1/test.sh`)
- [X] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `spades/3.12.0/README.md`)
   - [X] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [X] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [X] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [X] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing
