### PR TITLE
VADR 1.5.1 README.md update

### DIFF
--- a/vadr/1.5.1/README.md
+++ b/vadr/1.5.1/README.md
@@ -23,17 +23,20 @@ Available VADR models:
 - Dengue virus and other Flaviviridae
 - RSV v1.5.1-2
 
-Full documentation: https://github.com/ncbi/vadr#vadr-documentation-
+## FYI
 
-Docs on Coronavirus annotation: https://github.com/ncbi/vadr/wiki/Coronavirus-annotation
+- Mpox FYIs
+  - **Note:** Support for MonkeyPox genome annotation was added to the VADR software (July 2022) and is under active development. Things may change quickly. See the above documentation ^ to see the latest information on the state of MPXV annotation with VADR.
+  - Also be aware that some Mpox sequences may take up to **30 minutes** to annotate, depending on how divergent it is from the RefSeq NC_063383 sequence. Some sequences may only take a minute or so.
+- Dengue and other Flaviviridae models are located at `/opt/vadr/vadr-models-flavi/` within the container filesystem. To use these models, please specify `--mdir /opt/vadr/vadr-models-flavi/`. A full example command can be found below.
 
-Docs on MPXV annotation: https://github.com/ncbi/vadr/wiki/Monkeypox-virus-annotation
+### VADR Documentation
 
-**Note:** Support for MonkeyPox genome annotation was added to the VADR software (July 2022) and is under active development. Things may change quickly. See the above documentation ^ to see the latest information on the state of MPXV annotation with VADR.
-
-Also be aware that some sequences may take up to **30 minutes** to annotate, depending on how divergent it is from the RefSeq NC_063383 sequence. Some sequences may only take a minute or so.
-
-Docs on RSV annotation: https://github.com/ncbi/vadr/wiki/RSV-annotation
+- [Full documentation](https://github.com/ncbi/vadr#vadr-documentation-)
+- [Docs on Coronavirus annotation](https://github.com/ncbi/vadr/wiki/Coronavirus-annotation)
+- [Docs on Mpox annotation](https://github.com/ncbi/vadr/wiki/Monkeypox-virus-annotation)
+- [Docs on Dengue and other Flaviviridae annotation](https://github.com/ncbi/vadr/wiki/Available-VADR-model-files#dengue-virus-and-other-flaviviridae-refseq-vadr-models)
+- [Docs on RSV annotation](https://github.com/ncbi/vadr/wiki/RSV-annotation)
 
 ## Example Usage
 
@@ -41,22 +44,28 @@ Docs on RSV annotation: https://github.com/ncbi/vadr/wiki/RSV-annotation
 # trim terminal Ns from my input genome (VADR requires this as the first step)
 # for MPXV, adjust maxlen to 210000
 /opt/vadr/vadr/miniscripts/fasta-trim-terminal-ambigs.pl \
-        /data/SRR13957123.consensus.fa \
-        --minlen 50 \
-        --maxlen 30000 \
-        > /data/SRR13957123.consensus.trimmed.fasta
+    /data/SRR13957123.consensus.fa \
+    --minlen 50 \
+    --maxlen 30000 \
+    > /data/SRR13957123.consensus.trimmed.fasta
 
 # run v-annotate.pl using the sarscov2 model to annotate a trimmed input genome
 v-annotate.pl --noseqnamemax --glsearch -s -r --nomisc \
-       --mkey sarscov2 --lowsim5seq 6 \
-       --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn \
-       /data/SRR13957123.consensus.trimmed.fasta \
-       SRR13957123-vadr-outdir
+    --mkey sarscov2 --lowsim5seq 6 \
+    --lowsim3seq 6 --alt_fail lowscore,insertnn,deletinn \
+    /data/SRR13957123.consensus.trimmed.fasta \
+    SRR13957123-vadr-outdir
 
 # run v-annotate.pl using mpxv model to annotate a trimmed input genome
 v-annotate.pl --split --cpu 8 --glsearch -s -r --nomisc --mkey mpxv \
-        --r_lowsimok --r_lowsimxd 100 --r_lowsimxl 2000 --alt_pass discontn,dupregin \
-        --minimap2 --s_overhang 150 \
-        mpxv.consensus.trimmed.fasta \
-        mpxv-vadr-1.5-test-output
+    --r_lowsimok --r_lowsimxd 100 --r_lowsimxl 2000 --alt_pass discontn,dupregin \
+    --minimap2 --s_overhang 150 \
+    mpxv.consensus.trimmed.fasta \
+    mpxv-vadr-1.5-test-output
+
+# run v-annotate.pl using Flaviviridae model to annotate a Dengue viral genome
+v-annotate.pl --split --cpu 1 --group Dengue --nomisc --noprotid \
+    --mdir /opt/vadr/vadr-models-flavi/ --mkey flavi \
+    GCF_000862125.1_ViralProj15306_genomic.fna \
+    dengue-test-outdir
 ```

--- a/vadr/1.5.1/README.md
+++ b/vadr/1.5.1/README.md
@@ -28,7 +28,8 @@ Available VADR models:
 - Mpox FYIs
   - **Note:** Support for MonkeyPox genome annotation was added to the VADR software (July 2022) and is under active development. Things may change quickly. See the above documentation ^ to see the latest information on the state of MPXV annotation with VADR.
   - Also be aware that some Mpox sequences may take up to **30 minutes** to annotate, depending on how divergent it is from the RefSeq NC_063383 sequence. Some sequences may only take a minute or so.
-- Dengue and other Flaviviridae models are located at `/opt/vadr/vadr-models-flavi/` within the container filesystem. To use these models, please specify `--mdir /opt/vadr/vadr-models-flavi/`. A full example command can be found below.
+- Most of the VADR model files are located at `/opt/vadr/vadr-models` in the container filesystem and this path is stored in the globally accessible bash variable `$VADRMODELDIR`. For most applications, there is no need to specify `v-annotate.pl --mdir /path/to/model/files` since `$VADRMODELDIR` is set in the environment.
+  - The exception is that Dengue and other Flaviviridae model files are located at `/opt/vadr/vadr-models-flavi/` within the container filesystem. To use these models, please specify the 2 options: `v-annotate.pl --mdir /opt/vadr/vadr-models-flavi/ --mkey flavi`. A full example command can be found below.
 
 ### VADR Documentation
 


### PR DESCRIPTION
- added section & example cmd on Dengue annotation
- cleaned up link section
- improved formatting of example commands

Will fix issue #628 

No changes other than to `vadr/1.5.1/README.md`

View the rendered markdown here: https://github.com/StaPH-B/docker-builds/tree/cjk-vadr-doc-update/vadr/1.5.1

