### PR TITLE
Update freyja to have static freyja version

### DIFF
--- a/.github/workflows/update_freyja.yml
+++ b/.github/workflows/update_freyja.yml
@@ -35,17 +35,28 @@ jobs:
           
       - name: pull repo
         uses: actions/checkout@v3
-        
-      - name: get latest version of freyja in docker-builds repo
-        id: latest_version
-        run: | 
-          file=$(git log -1 --name-only --format=%cd --date=iso freyja/*/Dockerfile | grep Dockerfile | head -n 1 )
-          echo "the latest file is $file"
-          echo "file=$file" >> $GITHUB_OUTPUT
 
-          version=$(echo $file | cut -f 2 -d "/" | cut -f 1 -d "_")
-          echo "the latest version is $version"
-          echo "version=$version" >> $GITHUB_OUTPUT      
+# Keeping here in case we want to figure out why this doesn't work      
+#      - name: get latest version of freyja in docker-builds repo
+#        id: latest_version
+#        run: | 
+#          file=$(git log -1 --name-only --format=%cd --date=iso freyja/*/Dockerfile | grep Dockerfile | head -n 1 )
+#          echo "the latest file is $file"
+#          echo "file=$file" >> $GITHUB_OUTPUT
+#
+#          version=$(echo $file | cut -f 2 -d "/" | cut -f 1 -d "_")
+#          echo "the latest version is $version"
+#          echo "version=$version" >> $GITHUB_OUTPUT      
+
+      - name: set freyja version
+        id: latest_version
+        run: |
+          version=1.4.8
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=freyja/$version/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
 
       - name: set up docker buildx
         id: buildx


### PR DESCRIPTION
This PR removes the dynamic way I was originally looking for the most-recent version of Freyja

My original thought was to look for the most recent Freyja dockerfile, and extract the freyja version from that.

When I run the following locally
```
git log -1 --name-only --format=%cd --date=iso freyja/*/Dockerfile | grep Dockerfile | head -n 1
```
I get `freyja/1.4.8/Dockerfile`. I thought this would work.

When this is run in GA, the file is `freyja/1.2.1/Dockerfile`, which is the wrong file.

In lieu of this issue, I've commented out the old step and replaced it with one that  uses a static version. This means that every time we update Freya, we'll need to update this GA.