### PR TITLE
Remove cache in freyja GA

### DIFF
--- a/.github/workflows/update_freyja.yml
+++ b/.github/workflows/update_freyja.yml
@@ -62,13 +62,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: cache docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache-freyja
-          key: ${{ runner.os }}-buildx-freyja-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-buildx-freyja
-
       - name: build to test
         id: docker_build_to_test
         uses: docker/build-push-action@v3
@@ -77,8 +70,6 @@ jobs:
           target: test
           load: true
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache-freyja
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-freyja-new
           tags: freyja:update
 
       - name: get freyja database version
@@ -116,8 +107,6 @@ jobs:
           file: ${{ steps.latest_version.outputs.file }}
           target: app
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache-freyja
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-freyja-new # mode=max means export layers from all stage to cache
           tags: staphb/freyja:${{ steps.latest_version.outputs.version }}-${{ steps.db_version.outputs.version }}-${{ steps.date.outputs.date }}
             
       - name: Build and push to Quay
@@ -127,14 +116,7 @@ jobs:
           file: ${{ steps.latest_version.outputs.file }}
           target: app
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache-freyja
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-freyja-new # mode=max means export 
           tags: quay.io/staphb/freyja:${{ steps.latest_version.outputs.version }}-${{ steps.db_version.outputs.version }}-${{ steps.date.outputs.date }}
-
-      - name: Move cache # apparently prevents the cache from growing in size forever
-        run: |
-          rm -rf /tmp/.buildx-cache-freyja
-          mv /tmp/.buildx-cache-freyja-new /tmp/.buildx-cache-freyja
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
I've removed the lines for caching. I think this, in general, saves space in our GA repo, but I believe the cache is stopping Freyja from being created anew each day.

Right now the Freyja database tags are not updating, suggesting that the new databases aren't getting pulled.
