### PR TITLE
Github Action for Keeping MLST's Schemes current

### DIFF
--- a/.github/workflows/update_mlst.yml
+++ b/.github/workflows/update_mlst.yml
@@ -1,0 +1,87 @@
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent version of MLST and downloads the current MLST schemes.                                   #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update MLST
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 * * 1'
+
+run-name: Updating MLST
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: pull repo
+        uses: actions/checkout@v3
+
+      - name: set mlst version
+        id: latest_version
+        run: |
+          version=2.23.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=mlst/$version/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v3
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: test
+          load: true
+          push: false
+          tags: mlst:update
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push user-defined tag to DockerHub
+        id: docker_build_user_defined_tag
+        uses: docker/build-push-action@v3
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: staphb/mlst:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            
+      - name: Build and push to Quay
+        id: build
+        uses: docker/build-push-action@v3
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: quay.io/staphb/mlst:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/update_mlst.yml
+++ b/.github/workflows/update_mlst.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
           
       - name: pull repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: set mlst version
         id: latest_version
@@ -33,11 +33,11 @@ jobs:
 
       - name: set up docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: build to test
         id: docker_build_to_test
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           file: ${{ steps.latest_version.outputs.file }}
           target: test
@@ -53,13 +53,13 @@ jobs:
           echo "date=$date" >> $GITHUB_OUTPUT
       
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to Quay
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build and push user-defined tag to DockerHub
         id: docker_build_user_defined_tag
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           file: ${{ steps.latest_version.outputs.file }}
           target: app
@@ -76,7 +76,7 @@ jobs:
             
       - name: Build and push to Quay
         id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           file: ${{ steps.latest_version.outputs.file }}
           target: app

--- a/.github/workflows/update_mlst.yml
+++ b/.github/workflows/update_mlst.yml
@@ -27,7 +27,7 @@ jobs:
           version=2.23.0
           echo "version=$version" >> $GITHUB_OUTPUT 
           
-          file=mlst/$version/Dockerfile
+          file=mlst/2.23.0-2024-01/Dockerfile
           ls $file
           echo "file=$file" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
I have created a github action to keep MLST current with pubmlst.

This file is similar to that of the Github Action for Freyja.

There are some notable differences:
1. All the github action functions that are used are current.
2. There is no database version obtained from the built image. This means the tag is just `${version}-${date of deploy}`.
3. The frequency of the github action is set to every Monday at 7:30 am (as opposed to every day). I'm open to adjusting this to more or less frequently.
4. The 2.23.0 version of the dockerfile is not used. The 2.23.0-2024-01 Dockerfile is used because of how it downloads the databases.