### PR TITLE
MLST GA context instead of file

### DIFF
--- a/.github/workflows/update_mlst.yml
+++ b/.github/workflows/update_mlst.yml
@@ -39,7 +39,7 @@ jobs:
         id: docker_build_to_test
         uses: docker/build-push-action@v5
         with:
-          file: ${{ steps.latest_version.outputs.file }}
+          context: mlst/${{ steps.latest_version.outputs.version }}
           target: test
           load: true
           push: false


### PR DESCRIPTION
https://github.com/StaPH-B/docker-builds/actions/runs/8236077721 failed because of a build error. The way it was written before made it so the test couldn't be copied into the image. 

I've replaced "file" with "context" which _should_ fix that issue.