### PR TITLE
update pango aliasor weekly

### DIFF
--- a/.github/workflows/update_pango_aliasor.yml
+++ b/.github/workflows/update_pango_aliasor.yml
@@ -1,0 +1,82 @@
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent version of pango_aliasor and downloads the current pangolin lineages.                     #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update pango aliasor
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 * * 1'
+
+run-name: Updating pango aliasor
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: pull repo
+        uses: actions/checkout@v4
+
+      - name: set pango_aliasor version
+        id: latest_version
+        run: |
+          version=0.3.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=pango_aliasor/0.3.0/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v5
+        with:
+          context: pango_aliasor/${{ steps.latest_version.outputs.version }}
+          target: test
+          load: true
+          push: false
+          tags: pango_aliasor:update
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push user-defined tag to DockerHub
+        id: docker_build_user_defined_tag
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: |
+            staphb/pango_aliasor:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            staphb/pango_aliasor:latest
+            quay.io/staphb/pango_aliasor:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            quay.io/staphb/pango_aliasor:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This isn't a Dockerfile, it's a github action. I've had this on my todo list for a long time, but I need pango aliasor to update with the pangolin lineages. 

I was thinking weekly would be more than enough.

This github action 
1. builds the docker image to test
2. Then pushes the 'app' stage to quay and dockerhub with both the `latest` and `0.3.0-{date}` tags