### PR TITLE
fix bbtools deployment error

### DIFF
--- a/bbtools/39.10/Dockerfile
+++ b/bbtools/39.10/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
     pbzip2 \
     lbzip2 \
     bzip2 \
+    libdeflate-dev \
     wget \
     ca-certificates \
     procps && \


### PR DESCRIPTION
This should fix the deployment error of bbtools 39.10. 