### PR TITLE
Update ubuntu in GA to 'latest'

### DIFF
--- a/.github/workflows/build-to-deploy.yml
+++ b/.github/workflows/build-to-deploy.yml
@@ -48,7 +48,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo (+ download Git LFS dependencies)  # each job runs in an isolated environment, so need to check out the repo in each job
         uses: actions/checkout@v4

--- a/.github/workflows/build-to-test.yml
+++ b/.github/workflows/build-to-test.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   build_to_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/.github/workflows/run-singularity.yml
+++ b/.github/workflows/run-singularity.yml
@@ -20,7 +20,7 @@ on:
 jobs:
 
   build_singularity:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
I got an email recently about how github actions is going to stop supporting ubuntu-20.04, which is problematic for this repository.

I, therefore, went through all the GA workflows and changed all the ubuntu versions to 'ubuntu-latest'.