### PR TITLE
Use correct version of Freyja

### DIFF
--- a/.github/workflows/update_freyja.yml
+++ b/.github/workflows/update_freyja.yml
@@ -28,7 +28,7 @@ jobs:
           version=1.5.3
           echo "version=$version" >> $GITHUB_OUTPUT 
           
-          file=build-files/freyja/1.5.2-bf/Dockerfile
+          file=build-files/freyja/1.5.3/Dockerfile
           ls $file
           echo "file=$file" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Even though we have a Dockerfile for 1.5.3, we've been using version 1.5.2.