### PR TITLE
Update Dockerfile_mamba

### DIFF
--- a/dockerfile-template/Dockerfile_mamba
+++ b/dockerfile-template/Dockerfile_mamba
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # clean up conda garbage
 # make /data to use as a working directory
 RUN micromamba install --name base -c conda-forge -c bioconda SOFTWARENAME=${SOFTWARENAME_VERSION} && \
- micromamba clean -a -y && \
+ micromamba clean -a -f -y && \
  mkdir /data
 
 # 'ENV' instructions set environment variables that persist from the build into the resulting image

--- a/dockerfile-template/Dockerfile_mamba
+++ b/dockerfile-template/Dockerfile_mamba
@@ -18,7 +18,7 @@
 
 # 'FROM' defines the base docker image. This command has to come first in the file
 # The 'as' keyword lets you name the folowing stage. The production image uses everything to the 'app' stage.
-FROM mambaorg/micromamba:1.4.9 as app
+FROM mambaorg/micromamba:2.3.0-ubuntu22.04 AS app
 
 # List all software versions are ARGs near the top of the dockerfile
 # 'ARG' sets environment variables during the build stage
@@ -32,7 +32,7 @@ WORKDIR /
 
 # 'LABEL' instructions tag the image with metadata that might be important to the user
 
-LABEL base.image="mambaorg/micromamba:1.4.9"
+LABEL base.image="mambaorg/micromamba:2.3.0-ubuntu22.04"
 LABEL dockerfile.version="1"
 LABEL software="SOFTWARENAME"
 LABEL software.version="${SOFTWARENAME_VERSION}"
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install your desired software into the base conda/micromamba environment, pinning the version
 # clean up conda garbage
 # make /data to use as a working directory
-RUN micromamba install --name base -c conda-forge -c bioconda -c defaults SOFTWARENAME=${SOFTWARENAME_VERSION} && \
+RUN micromamba install --name base -c conda-forge -c bioconda SOFTWARENAME=${SOFTWARENAME_VERSION} && \
  micromamba clean -a -y && \
  mkdir /data
 
@@ -84,11 +84,10 @@ WORKDIR /data
 
 # A second FROM insruction creates a new stage
 # new base for testing
-FROM app as test
+FROM app AS test
 
-# so that conda/micromamba env is active when running below commands
-ENV ENV_NAME="base"
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
+# list all tools installed via micromamba (put these in the tool-specific REAMDME.md)
+RUN micromamba list -n base
 
 # set working directory so that all test inputs & outputs are kept in /test
 WORKDIR /test
@@ -108,6 +107,6 @@ RUN bash my_tests.sh
 
 # Option 2: write below common usage cases, for example with tb-profiler:
 RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_1.fastq.gz && \
-    wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_2.fastq.gz && \
-    tb-profiler profile -1 ERR1664619_1.fastq.gz -2 ERR1664619_2.fastq.gz -t 4 -p ERR1664619 --txt
+ wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_2.fastq.gz && \
+ tb-profiler profile -1 ERR1664619_1.fastq.gz -2 ERR1664619_2.fastq.gz -t 4 -p ERR1664619 --txt
 


### PR DESCRIPTION
The dockerfile that we recommend people use as a template is a little old, so I've tweaked some things.

- updated the base image to the current one of today
- added micrombamba list as a suggestion in the test stage
- removed some environmental variables (these are normally not needed when PATH is set correctly)