### PR TITLE
auto-emmtyper updates

### DIFF
--- a/.github/workflows/update_emmtyper.yml
+++ b/.github/workflows/update_emmtyper.yml
@@ -1,0 +1,81 @@
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent EMM types.                                                                                #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update EMMTYPER
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 1 * *'
+    # Runs at 07:30 on the 1st day of every month
+
+run-name: Updating EMMTYPER
+
+jobs:
+  update:
+    if: github.repository == 'StaPH-B/docker-builds'
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: pull repo
+        uses: actions/checkout@v4
+
+      - name: set version
+        id: latest_version
+        run: |
+          version=0.2.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=build-files/emmtyper/0.2.0-2412/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: test
+          load: true
+          push: false
+          tags: emmtyper:update
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push user-defined tag to DockerHub
+        id: docker_build_user_defined_tag
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: |
+            staphb/emmtyper:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            staphb/emmtyper:latest
+            quay.io/staphb/emmtyper:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            quay.io/staphb/emmtyper:latest

--- a/build-files/emmtyper/0.2.0-2412/README.md
+++ b/build-files/emmtyper/0.2.0-2412/README.md
@@ -15,7 +15,9 @@ Basic information on how to use this tool:
 Additional information:
 
 This image uses the most up-to-date fasta file for emm typing by downloading from https://ftp.cdc.gov/pub/infectious_diseases/biotech/tsemm/alltrimmed.tfa. The out-of-date files are removed and overwritten at the time of building and deployment.
-  
+
+This image is rebuilt every month on Dockerhub and Quay.io with the tag ${emmtyper version}-${data image was deployed}.
+
 Full documentation: https://github.com/MDU-PHL/emmtyper
 
 ## Example Usage


### PR DESCRIPTION
Emmtyper uses an external file for determining emm types.

This PR is for a github action that rebuilds the emmtyper image every month.

A line is also added to the readme of the files being used for this.