### PR TITLE
auto updating staramr

### DIFF
--- a/.github/workflows/update_staramr.yml
+++ b/.github/workflows/update_staramr.yml
@@ -1,0 +1,81 @@
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent databases.                                                                                #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update STARAMR
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 1 1 *'
+    # Runs at 07:30 on the 1st day of the 1st month of every year
+
+run-name: Updating STARAMR
+
+jobs:
+  update:
+    if: github.repository == 'StaPH-B/docker-builds'
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: pull repo
+        uses: actions/checkout@v4
+
+      - name: set version
+        id: latest_version
+        run: |
+          version=0.11.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=build-files/staramr/0.11.0/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: test
+          load: true
+          push: false
+          tags: staramr:update
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push user-defined tag to DockerHub
+        id: docker_build_user_defined_tag
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: |
+            staphb/staramr:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            staphb/staramr:latest
+            quay.io/staphb/staramr:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            quay.io/staphb/staramr:latest

--- a/build-files/staramr/0.11.0/README.md
+++ b/build-files/staramr/0.11.0/README.md
@@ -32,7 +32,7 @@ pointfinder_gene_drug_version = 070623
 resfinder_gene_drug_version   = 072423
 ```
 
-This image is re-built every year to the latest databases.
+This image is re-built every year to the latest databases with the tag {latest-version}={date of rebuilding}.
 
 Full documentation: https://github.com/phac-nml/staramr
 

--- a/build-files/staramr/0.11.0/README.md
+++ b/build-files/staramr/0.11.0/README.md
@@ -32,6 +32,8 @@ pointfinder_gene_drug_version = 070623
 resfinder_gene_drug_version   = 072423
 ```
 
+This image is re-built every year to the latest databases.
+
 Full documentation: https://github.com/phac-nml/staramr
 
 staramr scans bacterial genome contigs for AMR genes and plasmids


### PR DESCRIPTION
staramr uses the databases from resfinder, pointfinder, etc. It doesn't maintain these databases, just downloads them.

This github action rebuilds staramr every year to keep it current.