### PR TITLE
auto-update plassembler

### DIFF
--- a/.github/workflows/update_plassembler.yml
+++ b/.github/workflows/update_plassembler.yml
@@ -1,0 +1,81 @@
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent plasmid database.                                                                         #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update PLASSEMBLER
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 1 1,7 *'
+    # Runs at 07:30 on the 1st day of January and July
+
+run-name: Updating PLASSEMBLER
+
+jobs:
+  update:
+    if: github.repository == 'StaPH-B/docker-builds'
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: pull repo
+        uses: actions/checkout@v4
+
+      - name: set version
+        id: latest_version
+        run: |
+          version=1.8.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=build-files/plassembler/1.8.0/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: test
+          load: true
+          push: false
+          tags: plassembler:update
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push user-defined tag to DockerHub
+        id: docker_build_user_defined_tag
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: |
+            staphb/plassembler:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            staphb/plassembler:latest
+            quay.io/staphb/plassembler:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            quay.io/staphb/plassembler:latest

--- a/build-files/plassembler/1.8.0/README.md
+++ b/build-files/plassembler/1.8.0/README.md
@@ -277,7 +277,9 @@ The plsdb database that plassembler uses has been pre-downloaded at /plassembler
 ```
 plassembler download -d /plassembler_db
 ```
-  
+
+This image is rebuilt twice a year on January 1 and July 1 to keep the database current.
+
 Full documentation: https://github.com/gbouras13/plassembler
 
 ## Example Usage

--- a/build-files/plassembler/1.8.0/README.md
+++ b/build-files/plassembler/1.8.0/README.md
@@ -278,7 +278,7 @@ The plsdb database that plassembler uses has been pre-downloaded at /plassembler
 plassembler download -d /plassembler_db
 ```
 
-This image is rebuilt twice a year on January 1 and July 1 to keep the database current.
+This image is rebuilt twice a year on January 1 and July 1 to keep the database current. These have the tag {version}-{build date}
 
 Full documentation: https://github.com/gbouras13/plassembler
 


### PR DESCRIPTION
This PR is to add a github action to rebuild plassembler twice a year.

plassembler pulls the plasmid database from refseq, which updates four times a year. This will help keep the image useful to those who use it without the end-user needing to update the database every time they use it.