### PR TITLE
adding freyja for other organisms

### DIFF
--- a/.github/workflows/update_freyja_organisms.yml
+++ b/.github/workflows/update_freyja_organisms.yml
@@ -1,0 +1,97 @@
+
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent version of Freyja and downloading the most recent variant information.                    #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update Freyja for other organisms
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 * * 1'
+
+run-name: Updating Freyja for other oganisms
+
+jobs:
+  update:
+    if: github.repository == 'StaPH-B/docker-builds'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pathogen: [MPXV, H5NX, H5NX-cattle, H1N1pdm, FLU-B-VIC, H3N2, MEASLESN450, MEASLES, RSVa, RSVb, DENV1, DENV2, DENV3, DENV4]
+    steps:    
+      - name: pull repo
+        uses: actions/checkout@v4     
+
+      - name: set freyja version
+        id: latest_version
+        run: |
+          version=2.0.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=build-files/freyja/$version/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            FREYJA_PATHOGEN=${{ matrix.pathogen }}
+          file: ${{ steps.latest_version.outputs.file }}
+          target: test
+          load: true
+          push: false
+          tags: freyja:update-${{ matrix.pathogen }}
+
+      - name: get freyja database version
+        id: db_version
+        run: |
+          docker run freyja:update-${{ matrix.pathogen }} freyja demix --version
+          version="${{ matrix.pathogen }}-$(docker run freyja:update-${{ matrix.pathogen }} freyja demix --version | grep . | grep -v Barcode | head -n 1)"
+          echo "the latest version is $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push Dockerfile
+        id: docker_build_and_push
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          build-args: |
+            FREYJA_PATHOGEN=${{ matrix.pathogen }}
+          tags: |
+            staphb/freyja:${{ steps.latest_version.outputs.version }}-${{ steps.db_version.outputs.version }}-${{ steps.date.outputs.date }}
+            quay.io/staphb/freyja:${{ steps.latest_version.outputs.version }}-${{ steps.db_version.outputs.version }}-${{ steps.date.outputs.date }}
+
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_and_push.outputs.digest }}


### PR DESCRIPTION
I _think_ this will work.

This should build the freyja image for each of the available organisms. 

The matrix option is given a list of each pathogen that the readme says is available.
```
matrix:
        pathogen: [MPXV, H5NX, H5NX-cattle, H1N1pdm, FLU-B-VIC, H3N2, MEASLESN450, MEASLES, RSVa, RSVb, DENV1, DENV2, DENV3, DENV4]
```

Then the FREYJA_PATHOGEN arg is overwritten during build to test and later when it's time to deploy.
```
build-args: |
            FREYJA_PATHOGEN=${{ matrix.pathogen }}
```

This doesn't redo the tests, and I'm hoping that the SARS-CoV-2 specific tests also work okay-ish for these other organisms.

This will not overwrite the latest tag.