### PR TITLE
updating emmtyper monthly

### DIFF
--- a/.github/workflows/update_emmtyper.yml
+++ b/.github/workflows/update_emmtyper.yml
@@ -1,0 +1,81 @@
+##### ------------------------------------------------------------------------------------------------ #####
+##### This caller workflow tests, builds, and pushes the image to Docker Hub and Quay using the most   #####
+##### recent EMM types.                                                                                #####
+##### It takes no manual input.                                                                        #####
+##### ------------------------------------------------------------------------------------------------ #####
+
+name: Update EMMTYPER
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 1 * *'
+    # Runs at 07:30 on the 1st day of every month
+
+run-name: Updating EMMTYPER
+
+jobs:
+  update:
+    if: github.repository == 'StaPH-B/docker-builds'
+    runs-on: ubuntu-latest
+    steps:
+          
+      - name: pull repo
+        uses: actions/checkout@v4
+
+      - name: set version
+        id: latest_version
+        run: |
+          version=0.2.0
+          echo "version=$version" >> $GITHUB_OUTPUT 
+          
+          file=build-files/emmtyper/0.2.0-2412/Dockerfile
+          ls $file
+          echo "file=$file" >> $GITHUB_OUTPUT
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: build to test
+        id: docker_build_to_test
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: test
+          load: true
+          push: false
+          tags: emmtyper:update
+
+      - name: Get current date
+        id: date
+        run: |
+          date=$(date '+%Y-%m-%d')
+          echo "the date is $date"
+          echo "date=$date" >> $GITHUB_OUTPUT
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push user-defined tag to DockerHub
+        id: docker_build_user_defined_tag
+        uses: docker/build-push-action@v5
+        with:
+          file: ${{ steps.latest_version.outputs.file }}
+          target: app
+          push: true
+          tags: |
+            staphb/emmtyper:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            staphb/emmtyper:latest
+            quay.io/staphb/emmtyper:${{ steps.latest_version.outputs.version }}-${{ steps.date.outputs.date }}
+            quay.io/staphb/emmtyper:latest

--- a/build-files/emmtyper/0.2.0-2412/README.md
+++ b/build-files/emmtyper/0.2.0-2412/README.md
@@ -15,7 +15,9 @@ Basic information on how to use this tool:
 Additional information:
 
 This image uses the most up-to-date fasta file for emm typing by downloading from https://ftp.cdc.gov/pub/infectious_diseases/biotech/tsemm/alltrimmed.tfa. The out-of-date files are removed and overwritten at the time of building and deployment.
-  
+
+This image is rebuilt every month on Dockerhub and Quay.io with the tag ${emmtyper version}-${data image was deployed}.
+
 Full documentation: https://github.com/MDU-PHL/emmtyper
 
 ## Example Usage


### PR DESCRIPTION
There's no Dockerfile with this PR, but I do need a way to keep the emm types up to date in the emmtyper image hosted by staphb.

This PR is for a github action that will re-build the emmtyper image every month.

I can keep building it manually every time I remember/am nudged, but I'd rather have it build automatically.

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/build-files/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number in build-files (i.e. `docker-builds/build-files/spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `build-files/shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `docker-builds/build-files/spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing
