### PR TITLE
New templates

### DIFF
--- a/dockerfile-template/Dockerfile
+++ b/dockerfile-template/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Thank you for using this Dockerfile template!                     #####
 ##### This is an outline for the flow of building a docker image.       #####
@@ -8,56 +10,79 @@
 ##### Step 1. Set up the base image in the first stage.                 #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-# 'FROM' defines where the Dockerfile is starting to build from. This command has to come first in the file
-# The 'as' keyword lets you name the folowing stage. The production image uses everything to the 'app' stage.
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM ubuntu:noble AS app
 
-FROM ubuntu:jammy as app
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# List all software versions are ARGs near the top of the dockerfile
-# 'ARG' sets environment variables during the build stage
-# ARG variables are ONLY available during image build, they do not persist in the final image
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
 ARG SOFTWARENAME_VER="1.0.0"
 
-# 'LABEL' instructions tag the image with metadata that might be important to the user
-LABEL base.image="ubuntu:jammy"
-LABEL dockerfile.version="1"
-LABEL software="SoftwareName"
-LABEL software.version="${SOFTWARENAME_VER}"
-LABEL description="This software does X, Y, AND Z!"
-LABEL website="https://github.com/StaPH-B/docker-builds"
-LABEL license="https://github.com/StaPH-B/docker-builds/blob/master/LICENSE"
-LABEL maintainer="FirstName LastName"
-LABEL maintainer.email="my.email@email.com"
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
 
-# 'RUN' executes code during the build
-# Install dependencies via apt-get or yum if using a centos or fedora base
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# 'RUN' executes code during the build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
- dependency_a \
- dependency_b \
- dependency_c && \
- apt-get autoclean && rm -rf /var/lib/apt/lists/*
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-# Install and/or setup more things. Make /data for use as a working dir
-# For readability, limit one install per 'RUN' statement.
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
 
 # Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
 ARG BLAST_VER=2.9.0
-
 RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
- tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
- rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
- mkdir /data
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
 
-# 'ENV' instructions set environment variables that persist from the build into the resulting image
-# Use for e.g. $PATH and locale settings for compatibility with Singularity
-ENV PATH="/software-${SOFTWARENAME_VER}/bin:$PATH" \
- LC_ALL=C
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
 
-# 'CMD' instructions set a default command when the container is run. This is typically 'tool --help.'
-CMD [ "tool", "--help" ]
-
-# 'WORKDIR' sets working directory
+# 'WORKDIR' sets the default working directory. 
 WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
 
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Step 2. Set up the testing stage.                                 #####
@@ -65,28 +90,23 @@ WORKDIR /data
 ##### the test stage (or any stage after 'app') will be lost.           #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-# A second FROM insruction creates a new stage
-FROM app as test
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
 
-# set working directory so that all test inputs & outputs are kept in /test
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# Switch back to root briefly to install test-only tools (i.e. wget)
 WORKDIR /test
 
-# print help and version info; check dependencies (not all software has these options available)
-# Mostly this ensures the tool of choice is in path and is executable
-RUN softwarename --help && \
- softwarename --check && \
- softwarename --version
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
 
-# Demonstrate that the program is successfully installed - which is highly dependant on what the tool is.
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
 
-# Run the program's internal tests if available, for example with SPAdes:
-RUN spades.py --test
-
-# Option 1: write your own tests in a bash script in the same directory as your Dockerfile and copy them:
-COPY my_tests.sh .
-RUN bash my_tests.sh
-
-# Option 2: write below common usage cases, for example with tb-profiler:
-RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_1.fastq.gz && \
-    wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_2.fastq.gz && \
-    tb-profiler profile -1 ERR1664619_1.fastq.gz -2 ERR1664619_2.fastq.gz -t 4 -p ERR1664619 --txt
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/Dockerfile_R
+++ b/dockerfile-template/Dockerfile_R
@@ -1,0 +1,158 @@
+# syntax=docker/dockerfile:1
+
+# Use ARG so the version only needs to be defined once at the top.
+ARG SOFTWARENAME_VER="1.0.0"
+ARG R_VERSION="4.4.1"
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Thank you for using this Dockerfile template!                     #####
+##### This is an outline for the flow of building a docker image.       #####
+##### Compling software not needed at runtime is downloaded in the      #####
+##### builder stage, and then the actually needed items are copied to   #####
+##### the app stage.                                                    #####
+##### The docker image is built to the 'app' stage on dockerhub/quay.   #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 1. Set up the base image in the first stage.                 #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# Please note, all 'LABEL', 'ENV', and 'CMD' instructions will be lost
+# Also, files and executables are not carried over unless they are explicitly copied.
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS builder' naming is optional, but useful in the PR validation tests.
+# Rocker/r-ver is the industry standard for reproducible R environments.
+FROM rocker/r-ver:${R_VERSION} AS builder
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# 'RUN' executes code during the build
+# Install dependencies via apt-get or yum if using a centos or fedora base
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b \
+    dependency_c && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+
+# Install R packages
+# Pro tip: 'install2.r' (a Rocker utility) has better error handling for CI.
+# Use the -error flag so the build fails if a package fails to install.
+RUN install2.r --error --skipinstalled \
+    tidyverse \
+    BiocManager
+
+
+# Install specific bioinformatics packages via Bioconductor
+RUN Rscript -e 'BiocManager::install(c("ggtree", "treeio"))'
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM ubuntu:noble AS app
+
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
+
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# Copy the R library from the builder stage
+COPY --from=builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+
+# 'RUN' executes code during the build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
+
+# Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
+ARG BLAST_VER=2.9.0
+RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
+
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
+
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
+WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 2. Set up the testing stage.                                 #####
+##### The docker image is built to the 'test' stage before merging, but #####
+##### the test stage (or any stage after 'app') will be lost.           #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
+
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
+WORKDIR /test
+
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
+
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
+
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/Dockerfile_builder
+++ b/dockerfile-template/Dockerfile_builder
@@ -1,129 +1,144 @@
+# syntax=docker/dockerfile:1
+
+# Use ARG so the version only needs to be defined once at the top.
+ARG SOFTWARENAME_VER="1.0.0"
+
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Thank you for using this Dockerfile template!                     #####
 ##### This is an outline for the flow of building a docker image.       #####
+##### Compling software not needed at runtime is downloaded in the      #####
+##### builder stage, and then the actually needed items are copied to   #####
+##### the app stage.                                                    #####
 ##### The docker image is built to the 'app' stage on dockerhub/quay.   #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-##### Sometimes tools required to build a tool are not needed to run    #####
-##### it. This means that images are larger than they need to be. A way #####
-##### to reduce the size of an image, is to have a stage prior to 'app' #####
-##### where these temporarily-required tools are installed. Then, only  #####
-##### relevant executables and files are copied in to the 'app' stage.  #####
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-##### Step 1. Set up the builder stage as the first stage.              #####
+##### Step 1. Set up the base image in the first stage.                 #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
 # Please note, all 'LABEL', 'ENV', and 'CMD' instructions will be lost
 # Also, files and executables are not carried over unless they are explicitly copied.
 
-# 'FROM' defines where the Dockerfile is starting to build from. This command has to come first in the file
-FROM ubuntu:jammy as builder
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS builder' naming is optional, but useful in the PR validation tests.
+FROM ubuntu:noble AS builder
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
 
 # 'RUN' executes code during the build
 # Install dependencies via apt-get or yum if using a centos or fedora base
 RUN apt-get update && apt-get install -y --no-install-recommends \
- dependency_a \
- dependency_b \
- dependency_c && \
- apt-get autoclean && rm -rf /var/lib/apt/lists/*
+    dependency_a \
+    dependency_b \
+    dependency_c && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-# Install and/or setup more things. Make /data for use as a working dir
-# For readability, limit one install per 'RUN' statement.
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM ubuntu:noble AS app
+
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
+
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# COPY only the necessary files from the builder stage
+COPY --from=builder /tool-${SOFTWARENAME_VER}/bin/* /usr/local/bin/
+
+# 'RUN' executes code during the build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
 
 # Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
 ARG BLAST_VER=2.9.0
-
 RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
- tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
- rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
 
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-##### Step 2. Set up the base image in the 'app' stage.                 #####
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
 
-# 'FROM' defines where the Dockerfile is starting to build from. This command has to come first in the file
-# The 'as' keyword lets you name the folowing stage. The production image uses everything to the 'app' stage.
-
-FROM ubuntu:jammy as app
-
-# List all software versions are ARGs near the top of the dockerfile
-# 'ARG' sets environment variables during the build stage
-# ARG variables are ONLY available during image build, they do not persist in the final image
-ARG SOFTWARENAME_VER="1.0.0"
-
-# 'LABEL' instructions tag the image with metadata that might be important to the user
-LABEL base.image="ubuntu:jammy"
-LABEL dockerfile.version="1"
-LABEL software="SoftwareName"
-LABEL software.version="${SOFTWARENAME_VER}"
-LABEL description="This software does X, Y, AND Z!"
-LABEL website="https://github.com/StaPH-B/docker-builds"
-LABEL license="https://github.com/StaPH-B/docker-builds/blob/master/LICENSE"
-LABEL maintainer="FirstName LastName"
-LABEL maintainer.email="my.email@email.com"
-
-# copy in files and executables into app stage
-COPY --from=builder <source> <destination>
-
-# example copy in blast executable
-ARG BLAST_VER=2.9.0
-COPY --from=builder /bwa/bwa-${BWA_VER}/bwa /usr/local/bin
-
-# 'RUN' executes code during the build
-# Install dependencies via apt-get or yum if using a centos or fedora base
-# Please ensure ALL dependencies for running the tool make it into this stage
-RUN apt-get update && apt-get install -y --no-install-recommends \
- dependency_a \
- dependency_b \
- dependency_c && \
- apt-get autoclean && rm -rf /var/lib/apt/lists/*
-
-# Install and/or setup more things. Make /data for use as a working dir
-# For readability, limit one install per 'RUN' statement.
-
-# 'ENV' instructions set environment variables that persist from the build into the resulting image
-# Use for e.g. $PATH and locale settings for compatibility with Singularity
-ENV PATH="/software-${SOFTWARENAME_VER}/bin:$PATH" \
- LC_ALL=C
-
-# 'CMD' instructions set a default command when the container is run. This is typically 'tool --help.'
-CMD [ "tool", "--help" ]
-
-# 'WORKDIR' sets working directory
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
 WORKDIR /data
 
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
+
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-##### Step 3. Set up the testing stage.                                 #####
+##### Step 2. Set up the testing stage.                                 #####
 ##### The docker image is built to the 'test' stage before merging, but #####
 ##### the test stage (or any stage after 'app') will be lost.           #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-# A second FROM insruction creates a new stage
-# The test stage must be downstream from 'app'
-FROM app as test
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
 
-# set working directory so that all test inputs & outputs are kept in /test
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
 WORKDIR /test
 
-# print help and version info; check dependencies (not all software has these options available)
-# Mostly this ensures the tool of choice is in path and is executable
-RUN softwarename --help && \
- softwarename --check && \
- softwarename --version
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
 
-# Demonstrate that the program is successfully installed - which is highly dependant on what the tool is.
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
 
-# Run the program's internal tests if available, for example with SPAdes:
-RUN spades.py --test
-
-# Option 1: write your own tests in a bash script in the same directory as your Dockerfile and copy them:
-COPY my_tests.sh .
-RUN bash my_tests.sh
-
-# Option 2: write below common usage cases, for example with tb-profiler:
-RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_1.fastq.gz && \
-    wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_2.fastq.gz && \
-    tb-profiler profile -1 ERR1664619_1.fastq.gz -2 ERR1664619_2.fastq.gz -t 4 -p ERR1664619 --txt
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/Dockerfile_java
+++ b/dockerfile-template/Dockerfile_java
@@ -1,0 +1,144 @@
+# syntax=docker/dockerfile:1
+
+# Use ARG so the version only needs to be defined once at the top.
+ARG SOFTWARENAME_VER="1.0.0"
+ARG JAVA_VERSION="17"
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Thank you for using this Dockerfile template!                     #####
+##### This is an outline for the flow of building a docker image.       #####
+##### Compling software not needed at runtime is downloaded in the      #####
+##### builder stage, and then the actually needed items are copied to   #####
+##### the app stage.                                                    #####
+##### The docker image is built to the 'app' stage on dockerhub/quay.   #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 1. Set up the base image in the first stage.                 #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# Please note, all 'LABEL', 'ENV', and 'CMD' instructions will be lost
+# Also, files and executables are not carried over unless they are explicitly copied.
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS builder' naming is optional, but useful in the PR validation tests.
+FROM openjdk:${JAVA_VERSION}-jdk-slim-noble AS builder
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# 'RUN' executes code during the build
+# Install dependencies via apt-get or yum if using a centos or fedora base
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b \
+    dependency_c && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM openjdk:${JAVA_VERSION}-jre-slim-noble AS app
+
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
+
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/openjdk:${JAVA_VERSION}-jre-slim-noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# COPY only the necessary files from the builder stage
+COPY --from=builder /tool-${SOFTWARENAME_VER}/bin/* /usr/local/bin/
+
+# 'RUN' executes code during the build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
+
+# Java jars often need a wrapper script or alias
+RUN printf '#!/bin/bash\njava -jar /opt/tool/tool.jar "$@"\n' > /usr/local/bin/toolname && \
+    chmod +x /usr/local/bin/toolname
+
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
+
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
+WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 2. Set up the testing stage.                                 #####
+##### The docker image is built to the 'test' stage before merging, but #####
+##### the test stage (or any stage after 'app') will be lost.           #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
+
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
+WORKDIR /test
+
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
+
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
+
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/Dockerfile_mamba
+++ b/dockerfile-template/Dockerfile_mamba
@@ -12,7 +12,7 @@
 
 # 'FROM' defines where the Dockerfile is starting to build from.
 # The 'AS app' naming is required for the PR validation tests.
-FROM mambaorg/micromamba:2.5.0-noble AS app
+FROM mambaorg/micromamba:2.6.0-noble AS app
 
 # catches hidden failures in piped install steps
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -36,7 +36,7 @@ USER root
 # NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
 LABEL \
       # The exact base image used for the 'app' stage
-      org.opencontainers.image.base.name="docker.io/library/mambaorg/micromamba:2.5.0-noble" \
+      org.opencontainers.image.base.name="docker.io/library/mambaorg/micromamba:2.6.0-noble" \
       # The name of the software (e.g., "BWA" or "Samtools")
       org.opencontainers.image.title="SoftwareName" \
       # The version of the software itself

--- a/dockerfile-template/Dockerfile_mamba
+++ b/dockerfile-template/Dockerfile_mamba
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Thank you for using this Dockerfile template!                     #####
 ##### This is an outline for the flow of building a docker image.       #####
@@ -8,73 +10,90 @@
 ##### Step 1. Set up the base image in the first stage.                 #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-##### Conda can be a useful packaging manager that handles the          #####
-##### installation of tools and their dependencies. Generally, images   #####
-##### built via this method are larger, and may have file ownership     #####
-##### errors - which is why we generally recommend attempting to build  #####
-##### from source first.                                                #####
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM mambaorg/micromamba:2.5.0-noble AS app
 
-# 'FROM' defines the base docker image. This command has to come first in the file
-# The 'as' keyword lets you name the folowing stage. The production image uses everything to the 'app' stage.
-FROM mambaorg/micromamba:2.3.0-ubuntu22.04 AS app
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# List all software versions are ARGs near the top of the dockerfile
-# 'ARG' sets environment variables during the build stage
-# 'ARG' variables are ONLY available during image build, they do not persist in the final image
-ARG SOFTWARENAME_VERSION="1.0.4"
+ARG DEBIAN_FRONTEND=noninteractive
 
-# build and run as root users since micromamba image has 'mambauser' set as the $USER
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER="1.0.0"
+
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
+
+# Micromamba images start as 'mambauser', but root is needed for installation 
+# of system dependencies and setup project-specific users.
 USER root
-# set workdir to default for building; set to /data at the end
-WORKDIR /
 
-# 'LABEL' instructions tag the image with metadata that might be important to the user
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/mambaorg/micromamba:2.5.0-noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
 
-LABEL base.image="mambaorg/micromamba:2.3.0-ubuntu22.04"
-LABEL dockerfile.version="1"
-LABEL software="SOFTWARENAME"
-LABEL software.version="${SOFTWARENAME_VERSION}"
-LABEL description="This software does X, Y, AND Z!"
-LABEL website="https://github.com/StaPH-B/docker-builds"
-LABEL license="https://github.com/StaPH-B/docker-builds/blob/master/LICENSE"
-LABEL maintainer="FirstName LastName"
-LABEL maintainer.email="my.email@email.com"
-
-# 'RUN' executes code during the build
-# Install dependencies via apt-get or yum if using a centos or fedora base
+# 'RUN' executes code during the build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
- dependency_a \
- dependency_b \
- dependency_c && \
- apt-get autoclean && rm -rf /var/lib/apt/lists/*
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-# Example apt-get command for commonly-missing dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
- wget \
- ca-certificates \
- procps && \
- apt-get autoclean && rm -rf /var/lib/apt/lists/*
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
 
-# Install your desired software into the base conda/micromamba environment, pinning the version
-# clean up conda garbage
-# make /data to use as a working directory
+# Install desired software into the base conda/micromamba environment.
+# 'micromamba clean' removes index files and tarballs to keep the image slim.
 RUN micromamba install --name base -c conda-forge -c bioconda SOFTWARENAME=${SOFTWARENAME_VERSION} && \
- micromamba clean -a -f -y && \
- mkdir /data
+    micromamba clean -a -f -y && \
+    mkdir /data
 
-# 'ENV' instructions set environment variables that persist from the build into the resulting image
-# set the environment, add base conda/micromamba bin directory into path
-# set locale settings to UTF-8
-ENV PATH="/opt/conda/bin/:${PATH}" \
- LC_ALL=C.UTF-8
+# Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
+ARG BLAST_VER=2.9.0
+RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
 
-# 'CMD' instructions set a default command when the container is run. This is typically 'tool --help.'
-CMD [ "tool", "--help" ]
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
 
-# set final working directory to /data
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
 WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
 
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Step 2. Set up the testing stage.                                 #####
@@ -82,31 +101,27 @@ WORKDIR /data
 ##### the test stage (or any stage after 'app') will be lost.           #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-# A second FROM insruction creates a new stage
-# new base for testing
+# A second FROM instruction creates a new stage for automated testing.
 FROM app AS test
 
-# list all tools installed via micromamba (put these in the tool-specific REAMDME.md)
+# CRITICAL: StaPH-B CI requires 'micromamba list' to be run if micromamba is used.
 RUN micromamba list -n base
 
-# set working directory so that all test inputs & outputs are kept in /test
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
 WORKDIR /test
 
-# print help and version info; check dependencies (not all software has these options available)
-# Mostly this ensures the tool of choice is in path and is executable
-RUN softwarename --help && \
- softwarename --check && \
- softwarename --version
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
 
-# Run the program's internal tests if available, for example with SPAdes:
-RUN spades.py --test
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
 
-# Option 1: write your own tests in a bash script in the same directory as your Dockerfile and copy them:
-COPY my_tests.sh .
-RUN bash my_tests.sh
-
-# Option 2: write below common usage cases, for example with tb-profiler:
-RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_1.fastq.gz && \
- wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_2.fastq.gz && \
- tb-profiler profile -1 ERR1664619_1.fastq.gz -2 ERR1664619_2.fastq.gz -t 4 -p ERR1664619 --txt
-
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/Dockerfile_micromamba_builder
+++ b/dockerfile-template/Dockerfile_micromamba_builder
@@ -21,7 +21,7 @@ ARG SOFTWARENAME_VER="1.0.0"
 
 # 'FROM' defines where the Dockerfile is starting to build from.
 # The 'AS builder' naming is optional, but useful in the PR validation tests.
-FROM mambaorg/micromamba:2.5.0-noble AS builder
+FROM mambaorg/micromamba:2.6.0-noble AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/dockerfile-template/Dockerfile_micromamba_builder
+++ b/dockerfile-template/Dockerfile_micromamba_builder
@@ -1,0 +1,150 @@
+# syntax=docker/dockerfile:1
+
+# Use ARG so the version only needs to be defined once at the top.
+ARG SOFTWARENAME_VER="1.0.0"
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Thank you for using this Dockerfile template!                     #####
+##### This is an outline for the flow of building a docker image.       #####
+##### Compling software not needed at runtime is downloaded in the      #####
+##### builder stage, and then the actually needed items are copied to   #####
+##### the app stage.                                                    #####
+##### The docker image is built to the 'app' stage on dockerhub/quay.   #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 1. Set up the base image in the first stage.                 #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# Please note, all 'LABEL', 'ENV', and 'CMD' instructions will be lost
+# Also, files and executables are not carried over unless they are explicitly copied.
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS builder' naming is optional, but useful in the PR validation tests.
+FROM mambaorg/micromamba:2.5.0-noble AS builder
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# Switch to root to ensure we have permissions to create the environment
+USER root
+
+# Pro tip: Install into /opt/conda to make it easy to copy into app
+RUN micromamba install -y -n base -c conda-forge -c bioconda \
+    SOFTWARENAME=${SOFTWARENAME_VERSION} && \
+    micromamba clean -a -f -y
+
+RUN micromamba list
+
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM ubuntu:noble AS app
+
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
+
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# This brings only the binaries and libraries, not the Micromamba engine or cache.
+COPY --from=builder /opt/conda /opt/conda
+
+# 'RUN' executes code during the build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
+
+# Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
+ARG BLAST_VER=2.9.0
+RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
+
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
+
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
+WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 2. Set up the testing stage.                                 #####
+##### The docker image is built to the 'test' stage before merging, but #####
+##### the test stage (or any stage after 'app') will be lost.           #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
+
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
+WORKDIR /test
+
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
+
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
+
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...
+
+# Note: since micromamba is not installed in 'app', there is no 
+# RUN micromamba list -n base

--- a/dockerfile-template/Dockerfile_python3
+++ b/dockerfile-template/Dockerfile_python3
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Thank you for using this Dockerfile template!                     #####
 ##### This is an outline for the flow of building a docker image.       #####
@@ -5,68 +7,88 @@
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-##### Pip/pypi can be a useful packaging manager that handles the       #####
-##### installation of tools and their dependencies. This template uses  #####
-##### a base image for which python3 and pip are already installed, and #####
-##### is intended to be used for tools installed solely via pip (it's   #####
-##### like the pypi version of the Dockerfile_mamba template for conda  #####
-##### installations.)
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
-
-##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Step 1. Set up the base image in the first stage.                 #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-# 'FROM' defines where the Dockerfile is starting to build from. This command has to come first in the file
-# The 'as' keyword lets you name the folowing stage. The production image uses everything to the 'app' stage.
+# 'FROM' defines where the Dockerfile is starting to build from.
+# We use 'python:3.12-slim' as it is lightweight but includes the standard 
+# glibc library required by most bioinformatics binaries.
+FROM python:3.12-slim AS app
 
-FROM python:3.9.17-slim as app
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# List all software versions are ARGs near the top of the dockerfile
-# 'ARG' sets environment variables during the build stage
-# ARG variables are ONLY available during image build, they do not persist in the final image
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
 ARG SOFTWARENAME_VER="1.0.0"
 
-# 'LABEL' instructions tag the image with metadata that might be important to the user
-LABEL base.image="python:3.9.17-slim"
-LABEL dockerfile.version="1"
-LABEL software="SoftwareName"
-LABEL software.version="${SOFTWARENAME_VER}"
-LABEL description="This software does X, Y, AND Z!"
-LABEL website="https://github.com/StaPH-B/docker-builds"
-LABEL license="https://github.com/StaPH-B/docker-builds/blob/master/LICENSE"
-LABEL maintainer="FirstName LastName"
-LABEL maintainer.email="my.email@email.com"
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
 
-# 'RUN' executes code during the build
-# Install dependencies via apt-get or yum if using a centos or fedora base
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/python:3.12-slim" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# 'RUN' executes code during the build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    procps \
     dependency_a \
-    dependency_b \
-    dependency_c && \
+    dependency_b && \
     apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-# Install and/or setup more things. Make /data for use as a working dir
-# For readability, limit one install per 'RUN' statement.
-RUN pip install --no-cache software==${SOFTWARENAME_VER}
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
 
+# Install Python software via pip.
+# Use --no-cache-dir to keep the image size small.
+RUN pip install --no-cache-dir software==${SOFTWARENAME_VER}
 
-# Example: install pygenomeviz 0.3.2
-ARG PYGENOMEVIZ_VER="0.3.2"
+# Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
+ARG BLAST_VER=2.9.0
+RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
 
-RUN pip install --no-cache pygenomeviz==$PYGENOMEVIZ_VER 
-
-# 'ENV' instructions set environment variables that persist from the build into the resulting image
-# Use for e.g. $PATH and locale settings for compatibility with Singularity
-ENV PATH="/software-${SOFTWARENAME_VER}/bin:$PATH" \
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
     LC_ALL=C
 
-# 'CMD' instructions set a default command when the container is run. This is typically 'tool --help.'
-CMD [ "tool", "--help" ]
-
-# 'WORKDIR' sets working directory
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
 WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
 
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 ##### Step 2. Set up the testing stage.                                 #####
@@ -74,28 +96,28 @@ WORKDIR /data
 ##### the test stage (or any stage after 'app') will be lost.           #####
 ##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
 
-# A second FROM insruction creates a new stage
-FROM app as test
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
 
-# set working directory so that all test inputs & outputs are kept in /test
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# CRITICAL: StaPH-B CI requires 'pip list' to be run if 'pip install' is used.
+# This ensures that all installed dependency versions are recorded in the build logs.
+RUN pip list
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
 WORKDIR /test
 
-# print help and version info; check dependencies (not all software has these options available)
-# Mostly this ensures the tool of choice is in path and is executable
-RUN softwarename --help && \
-    softwarename --check && \
-    softwarename --version
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
 
-# Demonstrate that the program is successfully installed - which is highly dependant on what the tool is.
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
 
-# Run the program's internal tests if available, for example with SPAdes:
-RUN spades.py --test
-
-# Option 1: write your own tests in a bash script in the same directory as your Dockerfile and copy them:
-COPY my_tests.sh .
-RUN bash my_tests.sh
-
-# Option 2: write below common usage cases, for example with tb-profiler:
-RUN wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_1.fastq.gz && \
-    wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR166/009/ERR1664619/ERR1664619_2.fastq.gz && \
-    tb-profiler profile -1 ERR1664619_1.fastq.gz -2 ERR1664619_2.fastq.gz -t 4 -p ERR1664619 --txt
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/Dockerfile_rust
+++ b/dockerfile-template/Dockerfile_rust
@@ -1,0 +1,155 @@
+# syntax=docker/dockerfile:1
+
+# Use ARG so the version only needs to be defined once at the top.
+ARG SOFTWARENAME_VER="1.0.0"
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Thank you for using this Dockerfile template!                     #####
+##### This is an outline for the flow of building a docker image.       #####
+##### Compling software not needed at runtime is downloaded in the      #####
+##### builder stage, and then the actually needed items are copied to   #####
+##### the app stage.                                                    #####
+##### The docker image is built to the 'app' stage on dockerhub/quay.   #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 1. Set up the base image in the first stage.                 #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# Please note, all 'LABEL', 'ENV', and 'CMD' instructions will be lost
+# Also, files and executables are not carried over unless they are explicitly copied.
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS builder' naming is optional, but useful in the PR validation tests.
+FROM rust:1.82-slim-noble AS builder
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# 'RUN' executes code during the build
+# Install dependencies via apt-get or yum if using a centos or fedora base
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b \
+    dependency_c && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# Download and Compile the software
+# Use cargo's cache mount to speed up subsequent builds
+RUN wget https://github.com/example/tool/archive/v${SOFTWARENAME_VERSION}.tar.gz && \
+    tar -xzf v${SOFTWARENAME_VERSION}.tar.gz
+
+WORKDIR /tool-${SOFTWARENAME_VERSION}
+
+# Compile in release mode for maximum performance
+RUN cargo build --release
+
+
+# 'FROM' defines where the Dockerfile is starting to build from.
+# The 'AS app' naming is required for the PR validation tests.
+FROM ubuntu:noble AS app
+
+# catches hidden failures in piped install steps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# List all software versions as ARGs near the top of the dockerfile.
+# ARG variables are ONLY available during image build.
+ARG SOFTWARENAME_VER
+
+# default user id that can be overwritten for those that need to re-build images
+ARG UID=1000
+
+# 'LABEL' instructions tag the image with metadata.
+# These follow the OCI Image Spec. They help users and automated systems 
+# identify what is inside the container.
+# NOTE: The "org.opencontainers" labels are REQUIRED to pass StaPH-B CI tests.
+LABEL \
+      # The exact base image used for the 'app' stage
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:noble" \
+      # The name of the software (e.g., "BWA" or "Samtools")
+      org.opencontainers.image.title="SoftwareName" \
+      # The version of the software itself
+      org.opencontainers.image.version="${SOFTWARENAME_VER}" \
+      # The version of THIS Dockerfile (increment if you change the build logic)
+      org.opencontainers.image.revision="1" \
+      # A human-readable description of the tool
+      org.opencontainers.image.description="A brief description of what this tool does" \
+      # The project homepage or GitHub repository
+      org.opencontainers.image.url="https://github.com/StaPH-B/docker-builds" \
+      # Where users can find instructions or manuals for the software
+      org.opencontainers.image.documentation="https://github.com/StaPH-B/docker-builds" \
+      # The software license (e.g., MIT, GPL-3.0, Apache-2.0) for the software
+      org.opencontainers.image.licenses="GPL-3.0" \
+      # The person/group maintaining this Dockerfile
+      org.opencontainers.image.authors="firstName lastName <example@email.com>"
+
+# COPY only the necessary files from the builder stage
+COPY --from=builder /tool-${SOFTWARENAME_VERSION}/target/release/toolname /usr/local/bin/
+
+# 'RUN' executes code during the build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dependency_a \
+    dependency_b && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# Setup Non-Root User
+# Running as 'root' is a security risk.
+RUN useradd -m -u ${UID} -s /bin/bash appuser && \
+    mkdir -p /data /tmp && \
+    chown -R appuser:appuser /data
+
+# Example: install ncbi-blast+ 2.9.0 pre-compiled linux binaries
+ARG BLAST_VER=2.9.0
+RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    tar -xzf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz && \
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
+
+# 'ENV' instructions set environment variables that persist into the resulting image.
+ENV PATH="/ncbi-blast-${BLAST_VER}+/bin:$PATH" \
+    TMPDIR=/tmp \
+    HOME=/data \
+    LC_ALL=C
+
+# 'WORKDIR' sets the default working directory. 
+# StaPH-B Requirement: This MUST be set to /data.
+WORKDIR /data
+
+# Switch to the non-root user.
+USER appuser
+
+# 'CMD' instructions set a default command. This is typically 'tool --help.'
+CMD [ "blastn", "-help" ]
+
+
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+##### Step 2. Set up the testing stage.                                 #####
+##### The docker image is built to the 'test' stage before merging, but #####
+##### the test stage (or any stage after 'app') will be lost.           #####
+##### ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- #####
+
+# A second FROM instruction creates a new stage for automated testing.
+FROM app AS test
+
+USER appuser
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set working directory so that all test inputs & outputs are kept in /test
+# We switch back to root briefly if we need to install test-only tools, 
+# but generally, we stay as the 'staphb' user.
+WORKDIR /test
+
+# Print help and version info to ensure the tool is in the PATH and executable.
+RUN blastn -version
+
+# Option 1: Run your own tests in a bash script and copy them:
+# COPY my_tests.sh .
+# RUN bash my_tests.sh
+
+# Option 2: Write out usage cases directly:
+# RUN wget <data_url> && blastn -query input.fasta ...

--- a/dockerfile-template/README.md
+++ b/dockerfile-template/README.md
@@ -7,8 +7,10 @@ Please edit this readme with some basic information about the tool and how to us
 
 # <program> container
 
+This images is part of the StaPH-B/docker-builds project. More information can be found at https://github.com/StaPH-B/docker-builds.
+
 Main tool: [<program>](link to program)
-  
+
 Code repository:
 
 Additional tools:

--- a/dockerfile-template/README.md
+++ b/dockerfile-template/README.md
@@ -1,7 +1,7 @@
 <!-- 
 Please edit this readme with some basic information about the tool and how to use this container. 
 - Include information about databases and additional files that are included.
-- Keep it short - you don't need to recreate the documentation from the creators.
+- Keep it short - don't recreate the documentation from the creators.
 - Do not just copy and paste the readme or help for the tool. 
 -->
 
@@ -13,6 +13,40 @@ Code repository:
 
 Additional tools:
 - list: version
+
+<!-- 
+Please add dependencies installed via micromamba. 
+-->
+
+<details>
+<summary>Additional tools installed via micromamba:</summary>
+
+```
+List of packages in environment: "/opt/conda"
+
+  Name                     Version       Build                 Channel    
+────────────────────────────────────────────────────────────────────────────
+  _openmp_mutex            4.5           20_gnu                conda-forge
+  about-time               4.2.1         pyhd
+```
+</details>
+
+<!-- 
+Please add dependencies installed via pip. 
+-->
+
+<details>
+<summary>Additional tools installed via pip:</summary>
+
+```
+Package                Version
+---------------------- -----------
+annotated-types        0.7.0
+Brotli                 1.2.0
+certifi                2025.11.12
+```
+
+</details>
 
 Basic information on how to use this tool:
 - executable: <tool>


### PR DESCRIPTION
This PR contains some example templates that we can point to when people are creating new Dockerfiles.

- Dockerfile : basic 'app' and 'test' stage
- Dockerfile_builder : adds a 'builder' stage and corresponding 'COPY' layer to app
- Dockerfile_java : adds a java builder stage
- Dockerfile_mamba : updates the base image
- Dockerfile_micromamba_builder : adds a micromamba 'builder' stage, but is otherwise similar to Dockerfile_builder
- Dockerfile_python3 : is basically 'Dockerfile' with the python3-slim base
- Dockerfile_R : admittedly I haven't tested this, but it has a builder stage and some handy R stuff for installation
- Dockerfile_rust : is basically Dockerfile_builder using a 'rust' base image for 'builder'
- README.md : has added text for the micromamba and pip dependencies (which are optional)