### PR TITLE
Initial test of diamond 2.2.1. Issues with downloading test file. Add…

### DIFF
--- a/build-files/diamond/2.2.1/Dockerfile
+++ b/build-files/diamond/2.2.1/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:noble AS app
+
+ARG DIAMOND_VER="2.2.1"
+
+LABEL base.image="ubuntu:noble"
+LABEL dockerfile.version="1"
+LABEL software="DIAMOND"
+LABEL software.version="${DIAMOND_VER}"
+LABEL description="Accelerated BLAST compatible local sequence aligner."
+LABEL website="https://github.com/bbuchfink/diamond"
+LABEL license="https://github.com/bbuchfink/diamond/blob/master/LICENSE"
+LABEL maintainer="Kutluhan Incekara"
+LABEL maintainer.email="kutluhan.incekara@ct.gov"
+LABEL maintainer2="Raheel Ahmed"
+LABEL maintainer2.email="raheelsyedahmed@gmail.com"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    procps && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q https://github.com/bbuchfink/diamond/releases/download/v${DIAMOND_VER}/diamond-linux64.tar.gz &&\
+    tar -C /usr/local/bin -xvf diamond-linux64.tar.gz && \
+    rm diamond-linux64.tar.gz
+
+ENV LC_ALL=C
+
+CMD [ "diamond", "help" ]
+
+WORKDIR /data
+
+## Test ##
+FROM app AS test
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+RUN diamond test
+
+# Currently running into an issue with this URL, where a bot catcher page (Anubis Web Firewall Utility) prevents access before redirecting to the file directory.
+# Alternatives I've tried that have not succeeded:
+#   wget https://scop.berkeley.edu/downloads/scopeseq-2.07/astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa
+#   curl -L -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' 'https://scop.berkeley.edu/downloads/scopeseq-2.07/astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa' -o 'astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa'
+RUN wget --quiet --no-check-certificate https://scop.berkeley.edu/downloads/scopeseq-2.07/astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa &&\
+    cat astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa && \
+    diamond makedb --in astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa -d astral40 &&\
+    diamond blastp -q astral-scopedom-seqres-gd-sel-gs-bib-40-2.07.fa -d astral40 -o out.tsv --very-sensitive &&\
+    head out.tsv

--- a/build-files/diamond/2.2.1/README.md
+++ b/build-files/diamond/2.2.1/README.md
@@ -1,0 +1,32 @@
+# diamond container
+
+Main tool: [diamond](https://github.com/bbuchfink/diamond)
+  
+Code repository: https://github.com/bbuchfink/diamond
+
+Additional tools:
+- none
+
+Basic information on how to use this tool:
+- executable: `diamond`
+- help: `help`
+- version: `version`
+- description: DIAMOND is a sequence aligner for protein and translated DNA searches, designed for high performance analysis of big sequence data. The key features are:
+
+  - Pairwise alignment of proteins and translated DNA at 100x-10,000x speed of BLAST.
+  - Protein clustering of up to tens of billions of proteins
+  - Frameshift alignments for long read analysis.
+  - Low resource requirements and suitable for running on standard desktops or laptops.
+  - Various output formats, including BLAST pairwise, tabular and XML, as well as taxonomic classification.
+
+Full documentation: https://github.com/bbuchfink/diamond/wiki
+
+## Example Usage
+
+```bash
+# Protein alignment
+diamond makedb --in proteins.fa -d db
+diamond blastp -q query.fa -d db -o out.tsv --very-sensitive
+# Protein clustering
+diamond cluster -d proteins.fa -o clusters.tsv --approx-id 40 -M 12G --header
+```


### PR DESCRIPTION
…itional issue with now deprecated command diamond test.

<!--
Thank your for contributing to the Staph-B community!
Please fill in the appropriate checklist below and delete whatever is not relevant.

These recommendations are not meant as a means to keep people from contributing. 
If you need assistance with the following measures, submit your pull request anyway, and we will work with you...
Or you can contact us beforehand via slack or by sumitting a pull request https://github.com/StaPH-B/docker-builds/issues

Documentation on how to contribute can be found at https://staphb.org/docker-builds/contribute/
Documentation for how to create a Dockerfile can be found at https://staph-b.github.io/docker-builds/make_containers
A recommended Dockerfile template can be found at https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile


Please replace all '[ ]' with '[X]' to demonstrate completion.
-->

Pull Request (PR) checklist:
- [X] Include a description of what is in this pull request in this message.
- [ ] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/build-files/samtools/1.15` )
- [X] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number in build-files (i.e. `docker-builds/build-files/spades/3.12.0/Dockerfile`)
   - [ ] (optional) All test files are located in same directory as the Dockerfile (i.e. `build-files/shigatyper/2.0.1/test.sh`)
- [X] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `docker-builds/build-files/spades/3.12.0/README.md`)
   - [] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [X] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [ ] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [ ] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing

This PR is currently a draft PR to assess actions needed for an issue in installing diamond version 2.2.1. An image cannot currently be produced since the test file is unable to be downloaded; the file server for the test file now uses a Web Firewall called Anubis, which sends dummy data back instead of allowing access to the file URL specified. The output of the dummy data is shown below:

Alternative approaches I've attempted include trying to access the file with a user agent and with ca-certificates enabled, but I received the same blocked page data.

```
<!doctype html><html lang="en"><head><title>Oh noes!</title><link rel="stylesheet" href="/.within.website/x/xess/xess.min.css?cachebuster=1.25.0"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta name="robots" content="noindex,nofollow"><style>
body,
html {
height: 100%;
display: flex;
justify-content: center;
align-items: center;
margin-left: auto;
margin-right: auto;
}

.centered-div {
text-align: center;
}

#status {
font-variant-numeric: tabular-nums;
}

#progress {
display: none;
width: 90%;
width: min(20rem, 90%);
height: 2rem;
border-radius: 1rem;
overflow: hidden;
margin: 1rem 0 2rem;
outline-offset: 2px;
outline: #b16286 solid 4px;
}

.bar-inner {
background-color: #b16286;
height: 100%;
width: 0;
transition: width 0.25s ease-in;
}
</style><script id="anubis_version" type="application/json">"1.25.0"
</script><script id="anubis_challenge" type="application/json">null
</script><script id="anubis_base_prefix" type="application/json">""
</script><script id="anubis_public_url" type="application/json">""
</script></head><body id="top"><script type="ignore"><a href="/.within.website/x/cmd/anubis/api/honeypot/a95bd6fd-1424-4ea8-a698-5daa774dd1c2/init">Don't click me</a></script><main><h1 id="title" class="centered-div">Oh noes!</h1><div class="centered-div"><img id="image" alt="Sad Anubis" style="width:100%;max-width:256px;" src="/.within.website/x/cmd/anubis/static/img/reject.webp?cacheBuster=1.25.0"><p>Access Denied: error code 3bda83a2c7404d5.</p><p><a href="/">Go home</a> or if you believe you should not be blocked, please contact the webmaster at <a href="mailto:scop@compbio.berkeley.edu">scop@compbio.berkeley.edu</a></p></div><footer><div class="centered-div"><p>Protected by <a href="https://github.com/TecharoHQ/anubis">Anubis</a> From <a href="https://techaro.lol">Techaro</a>. Made with ❤️ in 🇨🇦.</p><p>Mascot design by <a href="https://bsky.app/profile/celphase.bsky.social">CELPHASE</a>.</p><p>This website is running Anubis version <code>1.25.0</code>.</p></div></footer></main></body></html>diamond v2.2.1.181 (C) Max Planck Society for the Advancement of Science, Benjamin J. Buchfink, University of Tuebingen
```
<!-- If this PR is for something else, please add extra descriptions -->

One other issue is diamond test. The command is now deprecated and shows the following output:
```
diamond v2.2.1.181 (C) Max Planck Society for the Advancement of Science, Benjamin J. Buchfink, University of Tuebingen
Documentation, support and updates available at http://www.diamondsearch.org
Please cite: http://dx.doi.org/10.1038/s41592-021-01101-x Nature Methods (2021)
The test workflow is deprecated. Unit testing is available via CTest. No action was taken.
```