### PR TITLE
adding busco verison 6.1.0

### DIFF
--- a/build-files/busco/6.1.0/Dockerfile
+++ b/build-files/busco/6.1.0/Dockerfile
@@ -1,0 +1,116 @@
+ARG BUSCO_VER="6.1.0"
+
+FROM ubuntu:noble AS app
+
+ARG BUSCO_VER
+ARG BBMAP_VER="39.97"
+ARG BLAST_VER="2.17.0"
+ARG MINIPROT_VER="0.18"
+ARG SEPP_VER="4.5.5"
+ARG METAEUK_VER="7-bba0d80"
+ARG DEBIAN_FRONTEND=noninteractive
+
+LABEL base.image="ubuntu:noble"
+LABEL dockerfile.version="1"
+LABEL software="BUSCO"
+LABEL software.version="${BUSCO_VER}"
+LABEL description="Assessing genome assembly and annotation completeness with Benchmarking Universal Single-Copy Orthologs"
+LABEL website="https://busco.ezlab.org/"
+LABEL license="https://gitlab.com/ezlab/busco/-/raw/master/LICENSE"
+LABEL maintainer="Kutluhan Incekara"
+LABEL maintainer.email="kutluhan.incekara@ct.gov"
+
+# install dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    wget \
+    bzip2 \
+    python-is-python3 \
+    python3-pip \
+    python3-pandas \
+    python3-setuptools\
+    python3-requests \
+    python3-matplotlib \
+    python3-biopython \
+    hmmer \
+    prodigal \
+    augustus \
+    openjdk-8-jre-headless \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/* && apt-get autoclean 
+
+# install other necessary tools
+# BioPython (python3-biopython installs 1.73. It causes python error in this version)
+# RUN pip install --no-cache-dir biopython
+
+# blast
+RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${BLAST_VER}/ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz &&\
+    tar -xvf ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz &&\
+    rm ncbi-blast-${BLAST_VER}+-x64-linux.tar.gz
+
+# sepp 
+RUN wget https://github.com/smirarab/sepp/archive/refs/tags/v${SEPP_VER}.tar.gz &&\
+    tar -xvf v${SEPP_VER}.tar.gz && rm v${SEPP_VER}.tar.gz &&\
+    cd sepp-${SEPP_VER} &&\
+    python setup.py config -c && python setup.py install
+
+# bbtools
+RUN wget https://sourceforge.net/projects/bbmap/files/BBMap_${BBMAP_VER}.tar.gz &&\
+    tar -xvf BBMap_${BBMAP_VER}.tar.gz &&\
+    rm BBMap_${BBMAP_VER}.tar.gz &&\    
+    mv /bbmap/* /usr/local/bin/
+
+# metaeuk
+RUN wget https://github.com/soedinglab/metaeuk/releases/download/${METAEUK_VER}/metaeuk-linux-sse41.tar.gz &&\
+    tar -xvf metaeuk-linux-sse41.tar.gz &&\
+    rm metaeuk-linux-sse41.tar.gz &&\
+    mv  /metaeuk/bin/* /usr/local/bin/
+
+# miniprot
+RUN wget https://github.com/lh3/miniprot/releases/download/v${MINIPROT_VER}/miniprot-${MINIPROT_VER}_x64-linux.tar.bz2 &&\
+    tar -C /usr/local/bin/ --strip-components=1 --no-same-owner -xvf miniprot-${MINIPROT_VER}_x64-linux.tar.bz2 miniprot-${MINIPROT_VER}_x64-linux/miniprot &&\
+    rm miniprot-${MINIPROT_VER}_x64-linux.tar.bz2
+
+# and finally busco
+RUN wget https://gitlab.com/ezlab/busco/-/archive/${BUSCO_VER}/busco-${BUSCO_VER}.tar.gz &&\
+    pip install --no-cache-dir --break-system-packages busco-${BUSCO_VER}.tar.gz && \
+    rm busco-${BUSCO_VER}.tar.gz
+
+ENV AUGUSTUS_CONFIG_PATH="/usr/share/augustus/config/" \
+    PATH="${PATH}:/ncbi-blast-${BLAST_VER}+/bin:/usr/share/augustus/scripts:/busco-${BUSCO_VER}/scripts" \
+    LC_ALL=C
+
+WORKDIR /data
+
+CMD ["busco", "-h"]
+
+## Tests ##
+FROM app AS test
+
+ARG BUSCO_VER
+
+RUN busco -h
+
+# getting test files
+WORKDIR /test
+
+RUN wget https://gitlab.com/ezlab/busco/-/archive/${BUSCO_VER}/busco-${BUSCO_VER}.tar.gz && \
+    tar -xvf busco-${BUSCO_VER}.tar.gz
+
+# run tests for bacteria and eukaryota
+RUN busco -i /test/busco-${BUSCO_VER}/test_data/bacteria/genome.fna -c 8 -m geno -f --out test_bacteria
+RUN busco -i /test/busco-${BUSCO_VER}/test_data/eukaryota/genome.fna -c 8 -m geno -f --out test_eukaryota
+RUN busco -i /test/busco-${BUSCO_VER}/test_data/eukaryota/genome.fna -l eukaryota_odb10 -c 8 -m geno -f --out test_eukaryota_augustus --augustus
+
+# generate plot
+RUN mkdir my_summaries &&\
+    find . -name "short_summary.*.json" -exec cp {} my_summaries \; &&\
+    busco --plot my_summaries
+
+# using actual data (Salmonella genome)
+WORKDIR /test_2
+
+RUN wget -q https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/010/941/835/GCA_010941835.1_PDT000052640.3/GCA_010941835.1_PDT000052640.3_genomic.fna.gz  && \
+    gzip -d GCA_010941835.1_PDT000052640.3_genomic.fna.gz && \
+    busco -m genome -i GCA_010941835.1_PDT000052640.3_genomic.fna -o busco_GCA_010941835.1 --cpu 4 --auto-lineage-prok && \
+    head busco_GCA_010941835.1/short_summary*.txt
+    

--- a/build-files/busco/6.1.0/README.md
+++ b/build-files/busco/6.1.0/README.md
@@ -1,0 +1,95 @@
+# Assessing genome assembly and annotation completeness with Benchmarking Universal Single-Copy Orthologs (BUSCO) container
+
+Main tool : [BUSCO](https://gitlab.com/ezlab/busco/)
+
+Additional tools:
+- BBTools 39.23
+- HMMER 3.3
+- Prodigal 2.6.3
+- BLAST+ 2.16.0
+- AUGUSTUS 3.3.3
+- MetaEuk (Release 7-bba0d80)
+- SEPP 4.5.6
+- Python 3.8.10
+- BioPython 1.83
+- R 3.6.3
+- Perl 5.30.0
+- OpenJDK 1.8.0_392
+- Miniprot 0.18
+
+Full documentation: https://busco.ezlab.org/busco_userguide.html
+
+This fully functional BUSCO docker image allows you to use all the program options. All additional tools were added to satisfy the requirements of those functions. This image does not contain any lineage dataset. BUSCO downloads the passed dataset name automatically while running. If a full path is given as lineage, this automated management will be disabled. The usage options are given below. Please refer to the BUSCO manual for further information.
+## Example Usage
+### Specific lineage
+```bash
+busco -i assembly.fasta -l bacteria_odb10 -o output -m genome
+```
+or
+```bash
+busco -i assembly.fasta -l /path/to/folder/bacteria_odb10 -o output -m genome
+```
+### Auto lineage selection:
+```bash
+busco -i assembly.fasta -o output -m genome --auto-lineage-prok
+```
+### Additional options:
+```bash
+  -i FASTA FILE, --in FASTA FILE
+                        Input sequence file in FASTA format. Can be an assembled genome or transcriptome (DNA), or protein sequences from an annotated gene set.
+  -o OUTPUT, --out OUTPUT
+                        Give your analysis run a recognisable short name. Output folders and files will be labelled with this name. WARNING: do not provide a path
+  -m MODE, --mode MODE  Specify which BUSCO analysis mode to run.
+                        There are three valid modes:
+                        - geno or genome, for genome assemblies (DNA)
+                        - tran or transcriptome, for transcriptome assemblies (DNA)
+                        - prot or proteins, for annotated gene sets (protein)
+  -l LINEAGE, --lineage_dataset LINEAGE
+                        Specify the name of the BUSCO lineage to be used.
+  --auto-lineage        Run auto-lineage to find optimum lineage path
+  --auto-lineage-prok   Run auto-lineage just on non-eukaryote trees to find optimum lineage path
+  --auto-lineage-euk    Run auto-placement just on eukaryote tree to find optimum lineage path
+  -c N, --cpu N         Specify the number (N=integer) of threads/cores to use.
+  -f, --force           Force rewriting of existing files. Must be used when output files with the provided name already exist.
+  -r, --restart         Continue a run that had already partially completed.
+  -q, --quiet           Disable the info logs, displays only errors
+  --out_path OUTPUT_PATH
+                        Optional location for results folder, excluding results folder name. Default is current working directory.
+  --download_path DOWNLOAD_PATH
+                        Specify local filepath for storing BUSCO dataset downloads
+  --datasets_version DATASETS_VERSION
+                        Specify the version of BUSCO datasets, e.g. odb10
+  --download_base_url DOWNLOAD_BASE_URL
+                        Set the url to the remote BUSCO dataset location
+  --update-data         Download and replace with last versions all lineages datasets and files necessary to their automated selection
+  --offline             To indicate that BUSCO cannot attempt to download files
+  --metaeuk_parameters METAEUK_PARAMETERS
+                        Pass additional arguments to Metaeuk for the first run. All arguments should be contained within a single pair of quotation marks, separated by commas. E.g. "--param1=1,--param2=2"
+  --metaeuk_rerun_parameters METAEUK_RERUN_PARAMETERS
+                        Pass additional arguments to Metaeuk for the second run. All arguments should be contained within a single pair of quotation marks, separated by commas. E.g. "--param1=1,--param2=2"
+  -e N, --evalue N      E-value cutoff for BLAST searches. Allowed formats, 0.001 or 1e-03 (Default: 1e-03)
+  --limit REGION_LIMIT  How many candidate regions (contig or transcript) to consider per BUSCO (default: 3)
+  --augustus            Use augustus gene predictor for eukaryote runs
+  --augustus_parameters AUGUSTUS_PARAMETERS
+                        Pass additional arguments to Augustus. All arguments should be contained within a single pair of quotation marks, separated by commas. E.g. "--param1=1,--param2=2"
+  --augustus_species AUGUSTUS_SPECIES
+                        Specify a species for Augustus training.
+  --long                Optimization Augustus self-training mode (Default: Off); adds considerably to the run time, but can improve results for some non-model organisms
+  --config CONFIG_FILE  Provide a config file
+  -v, --version         Show this version and exit
+  -h, --help            Show this help message and exit
+  --list-datasets       Print the list of available BUSCO datasets
+```
+### Plot
+Example usage of plotting script:
+```bash
+# collect short summaries
+mkdir my_summaries
+cp SPEC1/short_summary.generic.lineage1_odb10.SPEC1.txt my_summaries/.
+cp SPEC2/short_summary.generic.lineage2_odb10.SPEC2.txt my_summaries/.
+cp SPEC3/short_summary.specific.lineage2_odb10.SPEC3.txt my_summaries/.
+cp SPEC4/short_summary.generic.lineage3_odb10.SPEC4.txt my_summaries/.
+cp SPEC5/short_summary.generic.lineage4_odb10.SPEC5.txt my_summaries/.
+# plot via script
+python3 generate_plot.py –wd my_summaries
+```


### PR DESCRIPTION
I made an attempt to update busco to noble, but ran into errors.

This is a draft PR, and I am hoping I can return to this issue _soon_. I won't be offended if someone beats me to it.

Pull Request (PR) checklist:
- [x] Include a description of what is in this pull request in this message.
- [x] The dockerfile successfully builds to a test target for the user creating the PR. (i.e. `docker build --tag samtools:1.15test --target test docker-builds/build-files/samtools/1.15` )
- [x] Directory structure as name of the tool in lower case with special characters removed with a subdirectory of the version number in build-files (i.e. `docker-builds/build-files/spades/3.12.0/Dockerfile`)
   - [x] (optional) All test files are located in same directory as the Dockerfile (i.e. `build-files/shigatyper/2.0.1/test.sh`)
- [x] Create a simple container-specific [README.md](https://github.com/StaPH-B/docker-builds/blob/master/.github/workflow-templates/readme-template.md) in the same directory as the Dockerfile (i.e. `docker-builds/build-files/spades/3.12.0/README.md`)
   - [x] If this README is longer than 30 lines, there is an explanation as to why more detail was needed
- [x] Dockerfile includes the recommended [LABELS](https://github.com/StaPH-B/docker-builds/blob/master/dockerfile-template/Dockerfile#L8-L18) 
- [x] Main [README.md](https://github.com/StaPH-B/docker-builds/blob/master/README.md) has been updated to include the tool and/or version of the dockerfile(s) in this PR
- [x] [Program_Licenses.md](https://github.com/StaPH-B/docker-builds/blob/master/Program_Licenses.md) contains the tool(s) used in this PR and has been updated for any missing
